### PR TITLE
fix annual operationDischarge kWh

### DIFF
--- a/fine/storage.py
+++ b/fine/storage.py
@@ -1969,7 +1969,7 @@ class StorageModel(ComponentModel):
                         for ix in opSum.index
                     ],
                     opSum.columns,
-                ] = opSum.values
+                ] = opSum.values / esM.numberOfYears
                 optSummary.loc[
                     [
                         (


### PR DESCRIPTION
fixes wrong result in esm.getOptimizationSummary("StorageModel")

Before, the operationDischarge did show the same value for the annual result in `[kWh*h/a]` as well as for the total result of the current simulation (in `[kWh*h]`)


Wrong behavior for now:

![image](https://github.com/user-attachments/assets/eba8dc63-223b-4048-8535-c2838a721099)
