### PR TITLE
fix usage of hoursPerTimeStep for capacity

### DIFF
--- a/fine/component.py
+++ b/fine/component.py
@@ -2168,31 +2168,30 @@ class ComponentModel(metaclass=ABCMeta):
         constrSet1 = getattr(pyM, constrSetName + "1_" + abbrvName)
 
         if not pyM.hasSegmentation:
-            factor1 = 1 if isStateOfCharge else esM.hoursPerTimeStep
             if isOperationCommisYearDepending:
 
                 def op1(pyM, loc, compName, commis, ip, p, t):
-                    factor2 = (
+                    factor = (
                         1
                         if factorName is None
                         else getattr(compDict[compName], factorName)
                     )
                     return (
                         opVar[loc, compName, commis, ip, p, t]
-                        <= factor1 * factor2 * commisVar[loc, compName, commis]
+                        <= factor * commisVar[loc, compName, commis]
                     )
 
             else:
 
                 def op1(pyM, loc, compName, ip, p, t):
-                    factor2 = (
+                    factor = (
                         1
                         if factorName is None
                         else getattr(compDict[compName], factorName)
                     )
                     return (
                         opVar[loc, compName, ip, p, t]
-                        <= factor1 * factor2 * capVar[loc, compName, ip]
+                        <= factor * capVar[loc, compName, ip]
                     )
 
             setattr(
@@ -4015,6 +4014,8 @@ class ComponentModel(metaclass=ABCMeta):
                 # Calculate the annualized operational costs ox (OPEX)
                 tac_ox = resultsTAC_ox[ip]
 
+                factor = esM.hoursPerTimeStep
+
                 # Fill the optimization summary with the calculated values for invest, CAPEX and OPEX
                 # (due to capacity expansion).
                 optSummary_ip.loc[
@@ -4027,7 +4028,7 @@ class ComponentModel(metaclass=ABCMeta):
                         for ix in capOptVal.index
                     ],
                     capOptVal.columns,
-                ] = capOptVal.values
+                ] = capOptVal.values * factor
 
                 optSummary_ip.loc[
                     [(ix, "invest", "[" + esM.costUnit + "]") for ix in i.index],

--- a/fine/transmission.py
+++ b/fine/transmission.py
@@ -652,7 +652,7 @@ class TransmissionModel(ComponentModel):
                 return (
                     opVar[loc, compName, ip, p, t]
                     + opVar[compDict[compName]._mapI[loc], compName, ip, p, t]
-                    <= capVar[loc, compName, ip] * esM.hoursPerTimeStep
+                    <= capVar[loc, compName, ip]
                 )
 
             setattr(


### PR DESCRIPTION
the maximum capacity and chargeRate should not be depending on the hoursPerTimeStep as it is a total constraint

closes #62 

I am unsure whether this covers all the cases in `operationMode1`, I am also not sure why it is called `operationMode1` at all.
This might need some further fixes for features I am not using, but I think that this helps to get a fix for the issue and snippet provided in #62 - using the fix from this PR makes all the assertion pass