### PR TITLE
472 conversiondynamic class creates unnecessary binary operation variables for ramping constraints

### DIFF
--- a/fine/component.py
+++ b/fine/component.py
@@ -514,6 +514,21 @@ class Component(metaclass=ABCMeta):
                 "eosParameters": pd.DataFrame(data=np.array([[0,1,2,3],[0,1000, 1800, 2400],[0, 10, 18, 24]]).T, columns=["capacity", "totalInvest", "totalOpex"])
             }
         :type pwlcfParameters: dict
+
+        :param rampUpMax: A maximum ramping rate to limit the increase in the operation of the component as share of the installed capacity.
+            The maximum ramping is defined per hour and not per hoursPerTimeStep.
+            |br| * the default value is None
+        :type rampUpMax: None or float value in range \]0.0,1.0\]
+
+        :param rampDownMax: A maximum ramping rate to limit the decrease in the operation of the component as share of the installed capacity.
+            The maximum ramping is defined per hour and not per hoursPerTimeStep.
+            |br| * the default value is None
+        :type rampDownMax: None or float value in range \]0.0,1.0\]
+
+        :param useTemporalCyclicConstraints: If True, the temporal cyclic constraints are used.
+            This means that the operation of the first time steps are mathematically linked to the operation of the last time steps.
+            |br| * the default value is True
+        :type useTemporalCyclicConstraints: boolean
         """
         # Set general component data
         utils.isEnergySystemModelInstance(esM)

--- a/fine/component.py
+++ b/fine/component.py
@@ -514,21 +514,6 @@ class Component(metaclass=ABCMeta):
                 "eosParameters": pd.DataFrame(data=np.array([[0,1,2,3],[0,1000, 1800, 2400],[0, 10, 18, 24]]).T, columns=["capacity", "totalInvest", "totalOpex"])
             }
         :type pwlcfParameters: dict
-
-        :param rampUpMax: A maximum ramping rate to limit the increase in the operation of the component as share of the installed capacity.
-            The maximum ramping is defined per hour and not per hoursPerTimeStep.
-            |br| * the default value is None
-        :type rampUpMax: None or float value in range \]0.0,1.0\]
-
-        :param rampDownMax: A maximum ramping rate to limit the decrease in the operation of the component as share of the installed capacity.
-            The maximum ramping is defined per hour and not per hoursPerTimeStep.
-            |br| * the default value is None
-        :type rampDownMax: None or float value in range \]0.0,1.0\]
-
-        :param useTemporalCyclicConstraints: If True, the temporal cyclic constraints are used.
-            This means that the operation of the first time steps are mathematically linked to the operation of the last time steps.
-            |br| * the default value is True
-        :type useTemporalCyclicConstraints: boolean
         """
         # Set general component data
         utils.isEnergySystemModelInstance(esM)

--- a/fine/conversion.py
+++ b/fine/conversion.py
@@ -228,6 +228,21 @@ class Conversion(Component):
                 }
             }
         :type flowShares: dict
+        
+        :param rampUpMax: A maximum ramping rate to limit the increase in the operation of the component as share of the installed capacity.
+            The maximum ramping is defined per hour and not per hoursPerTimeStep.
+            |br| * the default value is None
+        :type rampUpMax: None or float value in range ]0.0,1.0]
+
+        :param rampDownMax: A maximum ramping rate to limit the decrease in the operation of the component as share of the installed capacity.
+            The maximum ramping is defined per hour and not per hoursPerTimeStep.
+            |br| * the default value is None
+        :type rampDownMax: None or float value in range ]0.0,1.0]
+
+        :param useTemporalCyclicConstraints: If True, the temporal cyclic constraints are used.
+            This means that the operation of the first time steps are mathematically linked to the operation of the last time steps.
+            |br| * the default value is True
+        :type useTemporalCyclicConstraints: boolean
         """
         Component.__init__(
             self,

--- a/fine/conversion.py
+++ b/fine/conversion.py
@@ -451,7 +451,6 @@ class Conversion(Component):
                     "Time series aggregation is not supported for rampUpMax and rampDownMax."
                 )
 
-
     def getDataForTimeSeriesAggregation(self, ip):
         """Function for getting the required data if a time series aggregation is requested.
 

--- a/fine/conversion.py
+++ b/fine/conversion.py
@@ -54,6 +54,9 @@ class Conversion(Component):
         emissionFactors=None,
         flowShares=None,
         pwlcfParameters=None,
+        rampUpMax=None,
+        rampDownMax=None,
+        useTemporalCyclicConstraints=True,
     ):
         # TODO: allow that the time series data or min/max/fixCapacity/eligibility is only specified for
         # TODO: eligible locations
@@ -319,6 +322,17 @@ class Conversion(Component):
         )
         self.aggregatedOperationRateFix = {}
         self.processedOperationRateFix = {}
+
+
+        self.rampUpMax = rampUpMax
+        self.rampDownMax = rampDownMax
+        self.useTemporalCyclicConstraints = useTemporalCyclicConstraints
+        utils.checkRampRates(
+            esM,
+            name,
+            self.rampUpMax,
+            self.rampDownMax,
+        )
 
         # partLoadMin
         self.processedPartLoadMin = utils.checkAndSetPartLoadMin(
@@ -879,6 +893,138 @@ class ConversionModel(ComponentModel):
         self.declareOpCommisConstrSet4(pyM, "opCommisConstrSet", rateMin)
         self.declareOpCommisConstrSetMinPartLoad(pyM, "opCommisConstrSet")
 
+    def declareRampingVarSets(self, esM, pyM):
+        """
+        Declare ramping constraint sets if ramp rates are given.
+        """
+        compDict, abbrvName = self.componentsDict, self.abbrvName
+        varSet = getattr(pyM, "operationVarSet_" + abbrvName)
+
+        # rampUpMax and rampDownMax
+
+        rampUpComps = [
+            compName
+            for (compName, comp) in compDict.items()
+            if comp.rampUpMax is not None
+        ]
+        rampDownComps = [
+            compName
+            for (compName, comp) in compDict.items()
+            if comp.rampDownMax is not None
+        ]
+
+        if rampDownComps:
+            def declareRampingSetUp(pyM):
+                return (
+                    (loc, compName, ip)
+                    for compName, comp in compDict.items()
+                    if compName in rampUpComps
+                    for loc in comp.processedLocationalEligibility.index
+                    for ip in esM.investmentPeriods
+                    if comp.processedLocationalEligibility[loc] == 1
+                )
+
+            setattr(
+                pyM,
+                "opConstrSet_rampUpMax_" + abbrvName,
+                pyomo.Set(dimen=3, initialize=declareRampingSetUp),
+            )
+        if rampUpComps:
+            def declareRampingSetDown(pyM):
+                return (
+                    (loc, compName, ip)
+                    for compName, comp in compDict.items()
+                    if compName in rampDownComps
+                    for loc in comp.processedLocationalEligibility.index
+                    for ip in esM.investmentPeriods
+                    if comp.processedLocationalEligibility[loc] == 1
+                )
+
+            setattr(
+                pyM,
+                "opConstrSet_rampDownMax_" + abbrvName,
+                pyomo.Set(dimen=3, initialize=declareRampingSetDown),
+            )
+        
+
+
+    def declareRampingConstraints(self, pyM, esM, rampingType):
+        """Set up the ramping contraints.
+
+
+        :param pyM: pyomo ConcreteModel which stores the mathematical formulation of the model.
+        :type pyM: pyomo Concrete Model
+
+        :param esM: EnergySystemModel instance representing the energy system in which the component should be modeled.
+        :type esM: esM - EnergySystemModel class instance
+
+        :param rampingType: Type of ramping constraints to set up. Can be either rampDownMax or rampUpMax
+            |br| * the default value is None.
+
+        """
+        if not rampingType in ["rampDownMax", "rampUpMax"]:
+            raise ValueError(
+                f"Ramping type {rampingType} is not valid. Please choose between rampDownMax and rampUpMax."
+            )
+
+        compDict, abbrvName = self.componentsDict, self.abbrvName
+
+        # first check if the parameter and therefore the set is defined
+        if not hasattr(pyM, f"opConstrSet_{rampingType}_" + abbrvName):
+            return
+
+        # if set exists, set up the constraint
+        opVar = getattr(pyM, "op_" + abbrvName)
+        capVar = getattr(pyM, "cap_" + abbrvName)
+
+        constrSetRamp = getattr(pyM, f"opConstrSet_{rampingType}_" + abbrvName)
+
+        factor = 1 if rampingType == "rampDownMax" else -1
+
+        if not pyM.hasSegmentation:
+            numberOfTimeSteps = len(esM.timeStepsPerPeriod)
+        else:
+            numberOfTimeSteps = len(esM.segmentsPerPeriod)
+
+        def ramping(pyM, loc, compName, ip, p, t):
+            rampRateMax = getattr(compDict[compName], rampingType)
+            isCyclic = getattr(compDict[compName], "useTemporalCyclicConstraints")
+            timeStepLength = (
+                esM.timeStepsPerPeriod[ip].to_dict()[p, t]
+                if pyM.hasSegmentation
+                else esM.hoursPerTimeStep
+            )
+
+            if t == 0 and not isCyclic:
+                return pyomo.Constraint.Skip
+            elif t == 0:
+                return (
+                    factor
+                    * (
+                        opVar[loc, compName, ip, p, numberOfTimeSteps - 1]
+                        - opVar[loc, compName, ip, p, t]
+                    )
+                    <= rampRateMax * timeStepLength * capVar[loc, compName, ip]
+                )
+            else:
+                return (
+                    factor
+                    * (
+                        opVar[loc, compName, ip, p, t - 1]
+                        - opVar[loc, compName, ip, p, t]
+                    )
+                    <= rampRateMax * timeStepLength * capVar[loc, compName, ip]
+                )
+
+        setattr(
+            pyM,
+            f"Constr{rampingType}_{abbrvName}",
+            pyomo.Constraint(constrSetRamp, pyM.intraYearTimeSet, rule=ramping),
+        )
+        
+
+
+
     def declareSets(self, esM, pyM):
         """
         Declare sets and dictionaries: design variable sets, operation variable set, operation mode sets and
@@ -928,6 +1074,9 @@ class ConversionModel(ComponentModel):
         # Declare maximum yearly full load hour set
         self.declareYearlyFullLoadHoursMaxSet(pyM)
         self.declareYearlyFullLoadHoursCommisMaxSet(pyM)
+        
+        # Declare ramping constraint sets
+        self.declareRampingVarSets(esM, pyM)
 
     ####################################################################################################################
     #                                                Declare variables                                                 #
@@ -983,6 +1132,8 @@ class ConversionModel(ComponentModel):
         # Capacity development variables [physicalUnit]
         self.declareCommissioningVars(pyM, esM)
         self.declareDecommissioningVars(pyM, esM)
+        
+        
 
     ####################################################################################################################
     #                                          Declare component constraints                                           #
@@ -1061,6 +1212,9 @@ class ConversionModel(ComponentModel):
             "op_commis",
             isOperationCommisYearDepending=True,
         )
+        
+        self.declareRampingConstraints(pyM, esM, rampingType="rampUpMax")
+        self.declareRampingConstraints(pyM, esM, rampingType="rampDownMax")
 
         ################################################################################################################
         #                                    Declare pathway constraints                                               #

--- a/fine/conversion.py
+++ b/fine/conversion.py
@@ -924,7 +924,7 @@ class ConversionModel(ComponentModel):
             if comp.rampDownMax is not None
         ]
 
-        if rampDownComps:
+        if rampUpComps:
 
             def declareRampingSetUp(pyM):
                 return (
@@ -941,7 +941,7 @@ class ConversionModel(ComponentModel):
                 "opConstrSet_rampUpMax_" + abbrvName,
                 pyomo.Set(dimen=3, initialize=declareRampingSetUp),
             )
-        if rampUpComps:
+        if rampDownComps:
 
             def declareRampingSetDown(pyM):
                 return (

--- a/fine/conversion.py
+++ b/fine/conversion.py
@@ -439,6 +439,18 @@ class Conversion(Component):
                         if hasTSA
                         else self.fullCommodityConversionFactors[timeInfo][commod]
                     )
+        if hasTSA:
+            if any(
+                x is not None
+                for x in [
+                    self.rampUpMax,
+                    self.rampDownMax,
+                ]
+            ):
+                raise ValueError(
+                    "Time series aggregation is not supported for rampUpMax and rampDownMax."
+                )
+
 
     def getDataForTimeSeriesAggregation(self, ip):
         """Function for getting the required data if a time series aggregation is requested.

--- a/fine/conversion.py
+++ b/fine/conversion.py
@@ -228,7 +228,7 @@ class Conversion(Component):
                 }
             }
         :type flowShares: dict
-        
+
         :param rampUpMax: A maximum ramping rate to limit the increase in the operation of the component as share of the installed capacity.
             The maximum ramping is defined per hour and not per hoursPerTimeStep.
             |br| * the default value is None
@@ -912,10 +912,7 @@ class ConversionModel(ComponentModel):
         Declare ramping constraint sets if ramp rates are given.
         """
         compDict, abbrvName = self.componentsDict, self.abbrvName
-        varSet = getattr(pyM, "operationVarSet_" + abbrvName)
-
         # rampUpMax and rampDownMax
-
         rampUpComps = [
             compName
             for (compName, comp) in compDict.items()
@@ -976,7 +973,7 @@ class ConversionModel(ComponentModel):
             |br| * the default value is None.
 
         """
-        if not rampingType in ["rampDownMax", "rampUpMax"]:
+        if rampingType not in ["rampDownMax", "rampUpMax"]:
             raise ValueError(
                 f"Ramping type {rampingType} is not valid. Please choose between rampDownMax and rampUpMax."
             )
@@ -1011,7 +1008,7 @@ class ConversionModel(ComponentModel):
 
             if t == 0 and not isCyclic:
                 return pyomo.Constraint.Skip
-            elif t == 0:
+            if t == 0:
                 return (
                     factor
                     * (
@@ -1020,7 +1017,7 @@ class ConversionModel(ComponentModel):
                     )
                     <= rampRateMax * timeStepLength * capVar[loc, compName, ip]
                 )
-            else:
+            if t > 0:
                 return (
                     factor
                     * (
@@ -1029,6 +1026,7 @@ class ConversionModel(ComponentModel):
                     )
                     <= rampRateMax * timeStepLength * capVar[loc, compName, ip]
                 )
+            return pyomo.Constraint.Skip
 
         setattr(
             pyM,

--- a/fine/conversion.py
+++ b/fine/conversion.py
@@ -323,7 +323,6 @@ class Conversion(Component):
         self.aggregatedOperationRateFix = {}
         self.processedOperationRateFix = {}
 
-
         self.rampUpMax = rampUpMax
         self.rampDownMax = rampDownMax
         self.useTemporalCyclicConstraints = useTemporalCyclicConstraints
@@ -914,6 +913,7 @@ class ConversionModel(ComponentModel):
         ]
 
         if rampDownComps:
+
             def declareRampingSetUp(pyM):
                 return (
                     (loc, compName, ip)
@@ -930,6 +930,7 @@ class ConversionModel(ComponentModel):
                 pyomo.Set(dimen=3, initialize=declareRampingSetUp),
             )
         if rampUpComps:
+
             def declareRampingSetDown(pyM):
                 return (
                     (loc, compName, ip)
@@ -945,8 +946,6 @@ class ConversionModel(ComponentModel):
                 "opConstrSet_rampDownMax_" + abbrvName,
                 pyomo.Set(dimen=3, initialize=declareRampingSetDown),
             )
-        
-
 
     def declareRampingConstraints(self, pyM, esM, rampingType):
         """Set up the ramping contraints.
@@ -1021,9 +1020,6 @@ class ConversionModel(ComponentModel):
             f"Constr{rampingType}_{abbrvName}",
             pyomo.Constraint(constrSetRamp, pyM.intraYearTimeSet, rule=ramping),
         )
-        
-
-
 
     def declareSets(self, esM, pyM):
         """
@@ -1074,7 +1070,7 @@ class ConversionModel(ComponentModel):
         # Declare maximum yearly full load hour set
         self.declareYearlyFullLoadHoursMaxSet(pyM)
         self.declareYearlyFullLoadHoursCommisMaxSet(pyM)
-        
+
         # Declare ramping constraint sets
         self.declareRampingVarSets(esM, pyM)
 
@@ -1132,8 +1128,6 @@ class ConversionModel(ComponentModel):
         # Capacity development variables [physicalUnit]
         self.declareCommissioningVars(pyM, esM)
         self.declareDecommissioningVars(pyM, esM)
-        
-        
 
     ####################################################################################################################
     #                                          Declare component constraints                                           #
@@ -1212,7 +1206,7 @@ class ConversionModel(ComponentModel):
             "op_commis",
             isOperationCommisYearDepending=True,
         )
-        
+
         self.declareRampingConstraints(pyM, esM, rampingType="rampUpMax")
         self.declareRampingConstraints(pyM, esM, rampingType="rampDownMax")
 

--- a/fine/subclasses/conversionDynamic.py
+++ b/fine/subclasses/conversionDynamic.py
@@ -311,7 +311,6 @@ class ConversionDynamicModel(ConversionModel):
             pyomo.Constraint(constrSetMinTime, pyM.intraYearTimeSet, rule=minimumTime2),
         )
 
-
     def declareComponentConstraints(self, esM, pyM):
         """
         Declare time independent and dependent constraints.

--- a/fine/subclasses/conversionDynamic.py
+++ b/fine/subclasses/conversionDynamic.py
@@ -21,8 +21,6 @@ class ConversionDynamic(Conversion):
         commodityConversionFactors,
         downTimeMin=None,
         upTimeMin=None,
-        rampUpMax=None,
-        rampDownMax=None,
         useTemporalCyclicConstraints=True,
         **kwargs,
     ):
@@ -67,8 +65,6 @@ class ConversionDynamic(Conversion):
         self.modelingClass = ConversionDynamicModel
         self.downTimeMin = downTimeMin
         self.upTimeMin = upTimeMin
-        self.rampUpMax = rampUpMax
-        self.rampDownMax = rampDownMax
         self.useTemporalCyclicConstraints = useTemporalCyclicConstraints
         utils.checkConversionDynamicSpecficDesignInputParams(self, esM)
 
@@ -92,8 +88,6 @@ class ConversionDynamic(Conversion):
                 for x in [
                     self.upTimeMin,
                     self.downTimeMin,
-                    self.rampUpMax,
-                    self.rampDownMax,
                 ]
             ):
                 raise ValueError(
@@ -136,8 +130,6 @@ class ConversionDynamicModel(ConversionModel):
             "partLoadMin",
             "downTimeMin",
             "upTimeMin",
-            "rampUpMax",
-            "rampDownMax",
         ]
         self.declareBinOpVarSet(
             esM,
@@ -156,18 +148,6 @@ class ConversionDynamicModel(ConversionModel):
             pyM,
             binaryOperationParameter=["upTimeMin"],
             binaryOperationSetName="opConstrSet_upTimeMin",
-        )
-        self.declareBinOpVarSet(
-            esM,
-            pyM,
-            binaryOperationParameter=["rampUpMax"],
-            binaryOperationSetName="opConstrSet_rampUpMax",
-        )
-        self.declareBinOpVarSet(
-            esM,
-            pyM,
-            binaryOperationParameter=["rampDownMax"],
-            binaryOperationSetName="opConstrSet_rampDownMax",
         )
 
     ####################################################################################################################
@@ -331,79 +311,6 @@ class ConversionDynamicModel(ConversionModel):
             pyomo.Constraint(constrSetMinTime, pyM.intraYearTimeSet, rule=minimumTime2),
         )
 
-    def rampingConstraints(self, pyM, esM, rampingType):
-        """Set up the ramping contraints.
-
-
-        :param pyM: pyomo ConcreteModel which stores the mathematical formulation of the model.
-        :type pyM: pyomo Concrete Model
-
-        :param esM: EnergySystemModel instance representing the energy system in which the component should be modeled.
-        :type esM: esM - EnergySystemModel class instance
-
-        :param rampingType: Type of ramping constraints to set up. Can be either rampDownMax or rampUpMax
-            |br| * the default value is None.
-
-        """
-        if not rampingType in ["rampDownMax", "rampUpMax"]:
-            raise ValueError(
-                f"Ramping type {rampingType} is not valid. Please choose between rampDownMax and rampUpMax."
-            )
-
-        compDict, abbrvName = self.componentsDict, self.abbrvName
-
-        # first check if the parameter and therefore the set is defined
-        if not hasattr(pyM, f"opConstrSet_{rampingType}_" + abbrvName):
-            return
-
-        # if set exists, set up the constraint
-        opVar = getattr(pyM, "op_" + abbrvName)
-        capVar = getattr(pyM, "cap_" + abbrvName)
-
-        constrSetRamp = getattr(pyM, f"opConstrSet_{rampingType}_" + abbrvName)
-
-        factor = 1 if rampingType == "rampDownMax" else -1
-
-        if not pyM.hasSegmentation:
-            numberOfTimeSteps = len(esM.timeStepsPerPeriod)
-        else:
-            numberOfTimeSteps = len(esM.segmentsPerPeriod)
-
-        def ramping(pyM, loc, compName, ip, p, t):
-            rampRateMax = getattr(compDict[compName], rampingType)
-            isCyclic = getattr(compDict[compName], "useTemporalCyclicConstraints")
-            timeStepLength = (
-                esM.timeStepsPerPeriod[ip].to_dict()[p, t]
-                if pyM.hasSegmentation
-                else esM.hoursPerTimeStep
-            )
-
-            if t == 0 and not isCyclic:
-                return pyomo.Constraint.Skip
-            elif t == 0:
-                return (
-                    factor
-                    * (
-                        opVar[loc, compName, ip, p, numberOfTimeSteps - 1]
-                        - opVar[loc, compName, ip, p, t]
-                    )
-                    <= rampRateMax * timeStepLength * capVar[loc, compName, ip]
-                )
-            else:
-                return (
-                    factor
-                    * (
-                        opVar[loc, compName, ip, p, t - 1]
-                        - opVar[loc, compName, ip, p, t]
-                    )
-                    <= rampRateMax * timeStepLength * capVar[loc, compName, ip]
-                )
-
-        setattr(
-            pyM,
-            f"Constr{rampingType}_{abbrvName}",
-            pyomo.Constraint(constrSetRamp, pyM.intraYearTimeSet, rule=ramping),
-        )
 
     def declareComponentConstraints(self, esM, pyM):
         """
@@ -432,5 +339,3 @@ class ConversionDynamicModel(ConversionModel):
         ################################################################################################################
         self.minimumTimeConstraints(pyM, esM, timeType="downTimeMin")
         self.minimumTimeConstraints(pyM, esM, timeType="upTimeMin")
-        self.rampingConstraints(pyM, esM, rampingType="rampUpMax")
-        self.rampingConstraints(pyM, esM, rampingType="rampDownMax")

--- a/fine/subclasses/conversionDynamic.py
+++ b/fine/subclasses/conversionDynamic.py
@@ -40,16 +40,6 @@ class ConversionDynamic(Conversion):
             |br| * the default value is None
         :type upTimeMin: None or integer value in range \[0,numberOfTimeSteps*hoursPerTimeStep\]
 
-        :param rampUpMax: A maximum ramping rate to limit the increase in the operation of the component as share of the installed capacity.
-            The maximum ramping is defined per hour and not per hoursPerTimeStep.
-            |br| * the default value is None
-        :type rampUpMax: None or float value in range \]0.0,1.0\]
-
-        :param rampDownMax: A maximum ramping rate to limit the decrease in the operation of the component as share of the installed capacity.
-            The maximum ramping is defined per hour and not per hoursPerTimeStep.
-            |br| * the default value is None
-        :type rampDownMax: None or float value in range \]0.0,1.0\]
-
         :param useTemporalCyclicConstraints: If True, the temporal cyclic constraints are used.
             This means that the operation of the first time steps are mathematically linked to the operation of the last time steps.
             |br| * the default value is True

--- a/fine/utils.py
+++ b/fine/utils.py
@@ -834,14 +834,32 @@ def checkInvestmentPeriodsCommodityConversion(commodityConversion, investmentPer
                 + f"periods of the esM ('{investmentPeriods}')",
             )
 
+def checkRampRates(
+    esM,
+    name,
+    rampUpMax,
+    rampDownMax,
+):
+    if rampUpMax is not None:
+        # Check if values are postive floats or ints
+        if not isinstance(rampUpMax, (float, int)) and rampUpMax <= 0:
+            raise TypeError(
+                "rampUpMax for " + name + " needs to be a positive float or int."
+            )
+
+    if rampDownMax is not None:
+        # Check if values are postive floats or ints
+        if not isinstance(rampDownMax, (float, int)) and rampDownMax <= 0:
+            raise TypeError(
+                "rampUpMax for " + name + " needs to be a positive float or int."
+            )
+
 
 def checkConversionDynamicSpecficDesignInputParams(compFancy, esM):
     downTimeMin = compFancy.downTimeMin
     upTimeMin = compFancy.upTimeMin
     numberOfTimeSteps = esM.numberOfTimeSteps
     name = compFancy.name
-    rampUpMax = compFancy.rampUpMax
-    rampDownMax = compFancy.rampDownMax
     bigM = compFancy.bigM
     useTemporalCyclicConstraints = compFancy.useTemporalCyclicConstraints
 
@@ -887,20 +905,7 @@ def checkConversionDynamicSpecficDesignInputParams(compFancy, esM):
                 + " needs to be an integer in the intervall ]0,numberOfTimeSteps]."
             )
 
-    if rampUpMax is not None:
-        # Check if values are postive floats or ints
-        if not isinstance(rampUpMax, (float, int)) and rampUpMax <= 0:
-            raise TypeError(
-                "rampUpMax for " + name + " needs to be a positive float or int."
-            )
-
-    if rampDownMax is not None:
-        # Check if values are postive floats or ints
-        if not isinstance(rampDownMax, (float, int)) and rampDownMax <= 0:
-            raise TypeError(
-                "rampUpMax for " + name + " needs to be a positive float or int."
-            )
-    if any(x is not None for x in [downTimeMin, upTimeMin, rampUpMax, rampDownMax]):
+    if any(x is not None for x in [downTimeMin, upTimeMin]):
         if bigM is None:
             raise ValueError(
                 "bigM for "

--- a/fine/utils.py
+++ b/fine/utils.py
@@ -834,6 +834,7 @@ def checkInvestmentPeriodsCommodityConversion(commodityConversion, investmentPer
                 + f"periods of the esM ('{investmentPeriods}')",
             )
 
+
 def checkRampRates(
     esM,
     name,


### PR DESCRIPTION
closes #472 

As suggested, moved ramp rates into regular conversionClass as they only create linear constraints.