### PR TITLE
Bug fix for setOptimalValues method in pwlcf model

### DIFF
--- a/.github/workflows/test_pandas_versions.yml
+++ b/.github/workflows/test_pandas_versions.yml
@@ -1,7 +1,7 @@
 on:
   workflow_dispatch:
-   push:
-     branches: ["bug_fix_set_optimal_values_pwlcf"]
+  push:
+    branches: ["bug_fix_set_optimal_values_pwlcf"]
 #  pull_request:
 #    branches: ["master"]
 

--- a/.github/workflows/test_pandas_versions.yml
+++ b/.github/workflows/test_pandas_versions.yml
@@ -1,9 +1,9 @@
 on:
   workflow_dispatch:
-  # push:
-  #   branches: ["485_test_dependency_range_new_release"]
-  pull_request:
-    branches: ["master"]
+   push:
+     branches: ["bug_fix_set_optimal_values_pwlcf"]
+#  pull_request:
+#    branches: ["master"]
 
 jobs:
   TestPushCondaForgeDev:

--- a/.github/workflows/test_pandas_versions.yml
+++ b/.github/workflows/test_pandas_versions.yml
@@ -1,9 +1,9 @@
 on:
   workflow_dispatch:
-  push:
-    branches: ["bug_fix_set_optimal_values_pwlcf"]
-#  pull_request:
-#    branches: ["master"]
+#  push:
+#    branches: ["bug_fix_set_optimal_values_pwlcf"]
+  pull_request:
+    branches: ["master"]
 
 jobs:
   TestPushCondaForgeDev:

--- a/fine/expansionModules/piecewiseLinearCostFunction.py
+++ b/fine/expansionModules/piecewiseLinearCostFunction.py
@@ -1037,23 +1037,29 @@ class PiecewiseLinearCostFunctionModel:
                     axis=0,
                 ).sort_index()
                 if len(eosComps) > 0:
-                    optSummary[ipName].loc[eosComps, "TAC", :] += optSummaryPwlcf[
-                        ipName
-                    ].loc[:, "TAC_EOS", :]
-                    optSummary[ipName].loc[eosComps, "NPVcontribution", :] += (
-                        optSummaryPwlcf[ipName].loc[:, "NPVcontribution_EOS", :]
+                    optSummary[ipName].loc[eosComps, "TAC", :] = (
+                        optSummary[ipName].loc[eosComps, "TAC", :].fillna(0)
+                        + optSummaryPwlcf[ipName].loc[eosComps, "TAC_EOS", :].values
                     )
-                    optSummary[ipName].loc[eosComps, "invest", :] += optSummaryPwlcf[
-                        ipName
-                    ].loc[:, "invest_EOS", :]
+                    optSummary[ipName].loc[eosComps, "NPVcontribution", :] = (
+                        optSummary[ipName].loc[eosComps, "NPVcontribution", :].fillna(0)
+                        + optSummaryPwlcf[ipName].loc[eosComps, "NPVcontribution_EOS", :].values
+                    )
+                    optSummary[ipName].loc[eosComps, "invest", :] = (
+                        optSummary[ipName].loc[eosComps, "invest", :].fillna(0)
+                        + optSummaryPwlcf[ipName].loc[eosComps, "invest_EOS", :].values
+                    )
                 if len(etlComps) > 0:
-                    optSummary[ipName].loc[etlComps, "TAC", :] += optSummaryPwlcf[
-                        ipName
-                    ].loc[:, "TAC_ETL", :]
-                    optSummary[ipName].loc[etlComps, "NPVcontribution", :] += (
-                        optSummaryPwlcf[ipName].loc[:, "NPVcontribution_ETL", :]
+                    optSummary[ipName].loc[etlComps, "TAC", :] = (
+                        optSummary[ipName].loc[etlComps, "TAC", :].fillna(0)
+                        + optSummaryPwlcf[ipName].loc[etlComps, "TAC_ETL", :].values
                     )
-                    optSummary[ipName].loc[eosComps, "invest", :] += optSummaryPwlcf[
-                        ipName
-                    ].loc[:, "invest_ETL", :]
+                    optSummary[ipName].loc[etlComps, "NPVcontribution", :] = (
+                        optSummary[ipName].loc[etlComps, "NPVcontribution", :].fillna(0)
+                        + optSummaryPwlcf[ipName].loc[etlComps, "NPVcontribution_ETL", :].values
+                    )
+                    optSummary[ipName].loc[etlComps, "invest", :] = (
+                        optSummary[ipName].loc[etlComps, "invest", :].fillna(0)
+                        + optSummaryPwlcf[ipName].loc[etlComps, "invest_ETL", :].values
+                    )
             model.optSummary = optSummary[esM.startYear]

--- a/fine/expansionModules/piecewiseLinearCostFunction.py
+++ b/fine/expansionModules/piecewiseLinearCostFunction.py
@@ -1043,7 +1043,9 @@ class PiecewiseLinearCostFunctionModel:
                     )
                     optSummary[ipName].loc[eosComps, "NPVcontribution", :] = (
                         optSummary[ipName].loc[eosComps, "NPVcontribution", :].fillna(0)
-                        + optSummaryPwlcf[ipName].loc[eosComps, "NPVcontribution_EOS", :].values
+                        + optSummaryPwlcf[ipName]
+                        .loc[eosComps, "NPVcontribution_EOS", :]
+                        .values
                     )
                     optSummary[ipName].loc[eosComps, "invest", :] = (
                         optSummary[ipName].loc[eosComps, "invest", :].fillna(0)
@@ -1056,7 +1058,9 @@ class PiecewiseLinearCostFunctionModel:
                     )
                     optSummary[ipName].loc[etlComps, "NPVcontribution", :] = (
                         optSummary[ipName].loc[etlComps, "NPVcontribution", :].fillna(0)
-                        + optSummaryPwlcf[ipName].loc[etlComps, "NPVcontribution_ETL", :].values
+                        + optSummaryPwlcf[ipName]
+                        .loc[etlComps, "NPVcontribution_ETL", :]
+                        .values
                     )
                     optSummary[ipName].loc[etlComps, "invest", :] = (
                         optSummary[ipName].loc[etlComps, "invest", :].fillna(0)

--- a/test/test_endogenousTechnologicalLearning.py
+++ b/test/test_endogenousTechnologicalLearning.py
@@ -83,10 +83,13 @@ def test_etl_NPV():
     Path("test_esM_etl.nc").unlink()
 
     esm_from_netcdf.optimize(timeSeriesAggregation=False, solver="glpk")
-    np.testing.assert_almost_equal(esm_from_netcdf.pyM.Obj(), esM.pyM.Obj(), 4.6906658)
-
-    print(esM.pyM.Obj())
-
+    np.testing.assert_almost_equal(esm_from_netcdf.pyM.Obj(), esM.pyM.Obj(), 5)
+    np.testing.assert_almost_equal(esm_from_netcdf.pyM.Obj(), 4.6906658, 5)
+    np.testing.assert_almost_equal(
+        esM.getOptimizationSummary('SourceSinkModel', ip=2030).loc['PV', 'invest', '[1 Euro]']['loc1'],
+        0.902734,
+        5
+    )
 
 def test_etl_stock_NPV():
     """Test case for basic npv calculation with etl module when stock is considered."""

--- a/test/test_endogenousTechnologicalLearning.py
+++ b/test/test_endogenousTechnologicalLearning.py
@@ -86,10 +86,13 @@ def test_etl_NPV():
     np.testing.assert_almost_equal(esm_from_netcdf.pyM.Obj(), esM.pyM.Obj(), 5)
     np.testing.assert_almost_equal(esm_from_netcdf.pyM.Obj(), 4.6906658, 5)
     np.testing.assert_almost_equal(
-        esM.getOptimizationSummary('SourceSinkModel', ip=2030).loc['PV', 'invest', '[1 Euro]']['loc1'],
+        esM.getOptimizationSummary("SourceSinkModel", ip=2030).loc[
+            "PV", "invest", "[1 Euro]"
+        ]["loc1"],
         0.902734,
-        5
+        5,
     )
+
 
 def test_etl_stock_NPV():
     """Test case for basic npv calculation with etl module when stock is considered."""


### PR DESCRIPTION
This PR fixes the addition of invest_ETL, NPVcontribution_ETL, TAC_ETL, invest_EOS, NPVcontribution_EOS, and TAC_EOS to the normal invest, NPVcontribution, and TAC in the optimization summary for Pandas versions <2.3.