### PR TITLE
adjust ruff check in pipeline and readme

### DIFF
--- a/.github/workflows/test_code_formatting.yml
+++ b/.github/workflows/test_code_formatting.yml
@@ -17,8 +17,6 @@ jobs:
           args: "--version"
           version: "0.13.1"
       - name: Check Linter
-        run: ruff check --output-format=github --config=pyproject.toml fine
-      # Needs to be activated to resolve issue https://github.com/FZJ-IEK3-VSA/FINE/issues/100
+        run: ruff check --output-format=github --config=pyproject.toml
       - name: Check Format
-
-        run: ruff format --diff --config pyproject.toml
+        run: ruff format --diff --config=pyproject.toml

--- a/README.md
+++ b/README.md
@@ -144,7 +144,8 @@ We use [ruff](https://docs.astral.sh/ruff) to ensure good coding style. Make
 sure to use it before contributing to the code base with
 
 ```bash
-ruff check fine
+ruff check --config=pyproject.toml
+ruff format --diff --config=pyproject.toml
 ```
 
 ## License


### PR DESCRIPTION
Small adjustments to remove an older comment, extend ruff coverage and adjust the readme so that the reader is prompted to do exactly the tests that are done in the pipeline. Solves #506 