### PR TITLE
645 Fix Renovate config: route gurobi-logtools to conda-forge channel

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -40,9 +40,21 @@
                 "/(^|/)requirements_dev\\.yml$/"
             ],
             "matchStrings": [
-                "- (?<depName>gurobi[a-zA-Z0-9_.-]*)[^\\n]*?(?<currentValue><=\\d[^\\n,]*)"
+                "- (?<depName>gurobi)[^\\n]*?(?<currentValue><=\\d[^\\n,]*)"
             ],
             "packageNameTemplate": "gurobi/{{{depName}}}",
+            "datasourceTemplate": "conda",
+            "versioningTemplate": "pep440"
+        },
+        {
+            "customType": "regex",
+            "managerFilePatterns": [
+                "/(^|/)requirements_dev\\.yml$/"
+            ],
+            "matchStrings": [
+                "- (?<depName>gurobi-[a-zA-Z0-9_.-]+)[^\\n]*?(?<currentValue><=\\d[^\\n,]*)"
+            ],
+            "packageNameTemplate": "conda-forge/{{{depName}}}",
             "datasourceTemplate": "conda",
             "versioningTemplate": "pep440"
         }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -28,7 +28,7 @@
                 "/(^|/)requirements_dev\\.yml$/"
             ],
             "matchStrings": [
-                "- (?<depName>(?!gurobi)[a-zA-Z0-9_.-]+)[^\\n]*?(?<currentValue><=\\d[^\\n,]*)"
+                "- (?<depName>geopandas|glpk|openpyxl|matplotlib|xlrd|pyomo|numpy|pandas|scipy|scikit-learn|xarray|rasterio|netcdf4|tsam|pwlf|psutil|gurobi-logtools|ipykernel|pytest|pytest-cov|pytest-xdist|nbval|ruff|mkdocs|mkdocs-material|mkdocstrings|mkdocstrings-python|mkdocs-jupyter|mkdocs-gen-files|mkdocs-literate-nav|mkdocs-section-index|griffe)[^\\n]*?(?<currentValue><=\\d[^\\n,]*)"
             ],
             "packageNameTemplate": "conda-forge/{{{depName}}}",
             "datasourceTemplate": "conda",
@@ -43,18 +43,6 @@
                 "- (?<depName>gurobi)[^\\n]*?(?<currentValue><=\\d[^\\n,]*)"
             ],
             "packageNameTemplate": "gurobi/{{{depName}}}",
-            "datasourceTemplate": "conda",
-            "versioningTemplate": "pep440"
-        },
-        {
-            "customType": "regex",
-            "managerFilePatterns": [
-                "/(^|/)requirements_dev\\.yml$/"
-            ],
-            "matchStrings": [
-                "- (?<depName>gurobi-[a-zA-Z0-9_.-]+)[^\\n]*?(?<currentValue><=\\d[^\\n,]*)"
-            ],
-            "packageNameTemplate": "conda-forge/{{{depName}}}",
             "datasourceTemplate": "conda",
             "versioningTemplate": "pep440"
         }


### PR DESCRIPTION
## Summary

- Replaces three wildcard-based regex managers with two managers using explicit package name alternations
- **conda-forge manager**: all tracked packages listed by exact name (`geopandas|glpk|openpyxl|...`) — no wildcard, no negative lookahead
- **gurobi manager**: matches only the literal string `gurobi` → `gurobi` channel
- Fixes `gurobi-logtools` being silently routed to the wrong conda channel

## Test plan
- [ ] Confirm Renovate processes the config without errors after merge (resolves #639)
- [ ] Confirm the Dependency Dashboard (#566) shows `gurobi-logtools` update PRs on next scheduled run (Tuesday night)

## Related Issues
Closes #645
Related: #566, #639

🤖 Generated with [Claude Code](https://claude.com/claude-code)