### PR TITLE
Add solver fallback: Gurobi to GLPK in tests

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,24 +4,37 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
-import pyomo.environ  # noqa: F401 - registers solver plugins
-from pyomo import opt
-
-from fine.utils import ImplementedSolvers
-
 import fine as fn
 from copy import deepcopy
 
 
 def _gurobi_available():
-    """Check if Gurobi solver is properly activated and available."""
+    """Check if Gurobi is installed with a valid non-restricted license.
+
+    Runs ``gurobi_cl --license`` and inspects the output for
+    "Restricted license", which indicates a size-limited test license
+    that is insufficient for the test suite.
+
+    See https://support.gurobi.com/hc/en-us/articles/13417565229713
+    """
     try:
-        return opt.SolverFactory("gurobi").available()
+        import subprocess  # noqa: PLC0415
+
+        result = subprocess.run(
+            ["gurobi_cl", "--license"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        output = (result.stdout + result.stderr).lower()
+        return result.returncode == 0 and "restricted license" not in output
     except Exception:
         return False
 
 
 SOLVER = "gurobi" if _gurobi_available() else "glpk"
+print(f"\n=== FINE test suite: using solver '{SOLVER}' ===\n")
 
 
 @pytest.fixture(scope="session")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,10 +4,31 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+import pyomo.environ  # noqa: F401 - registers solver plugins
+from pyomo import opt
+
 from fine.utils import ImplementedSolvers
 
 import fine as fn
 from copy import deepcopy
+
+
+def _gurobi_available():
+    """Check if Gurobi solver is properly activated and available."""
+    try:
+        return opt.SolverFactory("gurobi").available()
+    except Exception:
+        return False
+
+
+SOLVER = "gurobi" if _gurobi_available() else "glpk"
+
+
+@pytest.fixture(scope="session")
+def solver():
+    """Return the best available solver, falling back to GLPK if Gurobi is unavailable."""
+    return SOLVER
+
 
 sys.path.append(
     str(
@@ -1429,7 +1450,7 @@ def multi_node_test_esM_optimized(get_data_fixture):
 
     esM.optimize(
         timeSeriesAggregation=True,
-        solver=ImplementedSolvers.STANDARD_SOLVER.value,
+        solver=SOLVER,
     )
 
     return esM

--- a/test/test_QPinvest.py
+++ b/test/test_QPinvest.py
@@ -2,7 +2,18 @@ import fine as fn
 import pandas as pd
 import pytest
 
+import pyomo.environ  # noqa: F401 - registers solver plugins
+from pyomo import opt
 
+
+def _gurobi_available():
+    try:
+        return opt.SolverFactory("gurobi").available()
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _gurobi_available(), reason="Gurobi not available")
 @pytest.mark.parametrize("capacityMin", [0, 5])
 def test_QPinvest(capacityMin):
     capacityMin_variation = 5

--- a/test/test_QPinvest.py
+++ b/test/test_QPinvest.py
@@ -2,13 +2,19 @@ import fine as fn
 import pandas as pd
 import pytest
 
-import pyomo.environ  # noqa: F401 - registers solver plugins
-from pyomo import opt
-
-
 def _gurobi_available():
     try:
-        return opt.SolverFactory("gurobi").available()
+        import subprocess  # noqa: PLC0415
+
+        result = subprocess.run(
+            ["gurobi_cl", "--license"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        output = (result.stdout + result.stderr).lower()
+        return result.returncode == 0 and "restricted license" not in output
     except Exception:
         return False
 


### PR DESCRIPTION
## Summary
- Adds a `_gurobi_available()` check and `SOLVER` constant in `test/conftest.py` that detects whether Gurobi is properly licensed and falls back to GLPK if not.
- Provides a `solver` session-scoped fixture for tests to use the best available solver.
- Skips `test_QPinvest` (requires Gurobi's QP capabilities) when Gurobi is unavailable.

This avoids exposing the Gurobi API key to external repositories and allows CI to safely run the test suite on PRs from forks.

Closes #652

## Test plan
- [x] `test_QPinvest.py` passes when Gurobi is available
- [ ] `test_QPinvest.py` is skipped when Gurobi is unavailable
- [x] `test_fixtures.py` passes (uses `multi_node_test_esM_optimized` fixture which now uses `SOLVER`)
- [ ] Full test suite passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)