### PR TITLE
Fix missing solver fallback in test optimize() calls

### DIFF
--- a/test/IOManagement/test_resultExcelOutput.py
+++ b/test/IOManagement/test_resultExcelOutput.py
@@ -100,7 +100,7 @@ def test_compareResults_longClassNames():
                 f"Test for class: {possibleClass} not implemented. If a new subclass is added, also add a possible abbreviation in case the name is too long for saving to excel."
             )
 
-    esM.optimize()
+    esM.optimize(solver=ImplementedSolvers.STANDARD_SOLVER.value)
 
     # save to excel:
 

--- a/test/aggregations/spatialAggregation/test_manager.py
+++ b/test/aggregations/spatialAggregation/test_manager.py
@@ -257,7 +257,10 @@ def test_spatial_aggregation_parameter_based(
     assert len(aggregated_esM.locations) == n_regions
     #  Additional check - if the optimization runs through
     aggregated_esM.aggregateTemporally(numberOfTypicalPeriods=4)
-    aggregated_esM.optimize(timeSeriesAggregation=True)
+    aggregated_esM.optimize(
+        timeSeriesAggregation=True,
+        solver=ImplementedSolvers.STANDARD_SOLVER.value,
+    )
 
 
 def test_aggregation_of_balanceLimit(balanceLimitConstraint_test_esM):


### PR DESCRIPTION
## Summary
- Add `solver=ImplementedSolvers.STANDARD_SOLVER.value` to two `optimize()` calls that were missed in #654/#655
- Fixes `test_spatial_aggregation_parameter_based` and `test_compareResults_longClassNames` failing with `GurobiError: Model too large for size-limited license`

## Test plan
- [ ] CI tests pass (the 5 previously failing tests should now use the fallback solver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)