### PR TITLE
fix(renovate): prevent prefix collisions in requirements_dev.yml regex

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -28,7 +28,7 @@
                 "/(^|/)requirements_dev\\.yml$/"
             ],
             "matchStrings": [
-                "- (?<depName>geopandas|glpk|openpyxl|matplotlib|xlrd|pyomo|numpy|pandas|scipy|scikit-learn|xarray|rasterio|netcdf4|tsam|pwlf|psutil|gurobi-logtools|ipykernel|pytest|pytest-cov|pytest-xdist|nbval|ruff|mkdocs|mkdocs-material|mkdocstrings|mkdocstrings-python|mkdocs-jupyter|mkdocs-gen-files|mkdocs-literate-nav|mkdocs-section-index|griffe)[^\\n]*?(?<currentValue><=\\d[^\\n,]*)"
+                "- (?<depName>geopandas|glpk|openpyxl|matplotlib|xlrd|pyomo|numpy|pandas|scikit-learn|scipy|xarray|rasterio|netcdf4|tsam|pwlf|psutil|gurobi-logtools|ipykernel|pytest-cov|pytest-xdist|pytest|nbval|ruff|mkdocs-material|mkdocs-jupyter|mkdocs-gen-files|mkdocs-literate-nav|mkdocs-section-index|mkdocstrings-python|mkdocstrings|mkdocs|griffe)\\s[^\\n]*?(?<currentValue><=\\d[^\\n,]*)"
             ],
             "packageNameTemplate": "conda-forge/{{{depName}}}",
             "datasourceTemplate": "conda",
@@ -40,7 +40,7 @@
                 "/(^|/)requirements_dev\\.yml$/"
             ],
             "matchStrings": [
-                "- (?<depName>gurobi)[^\\n]*?(?<currentValue><=\\d[^\\n,]*)"
+                "- (?<depName>gurobi)\\s[^\\n]*?(?<currentValue><=\\d[^\\n,]*)"
             ],
             "packageNameTemplate": "gurobi/{{{depName}}}",
             "datasourceTemplate": "conda",


### PR DESCRIPTION
## Summary

Fixes a bug in the custom Renovate regex manager that caused mislabeled / wrong-version PRs such as #661, #683, #684.

## Root cause

The custom regex for `requirements_dev.yml` in [.github/renovate.json](.github/renovate.json) was:

```regex
- (?<depName>...|pytest|pytest-cov|pytest-xdist|...|mkdocs|mkdocs-material|mkdocstrings|mkdocstrings-python|mkdocs-jupyter|...)[^\n]*?(?<currentValue><=\d[^\n,]*)
```

Regex alternation is left-to-right, so on a line like `- mkdocstrings >=0.25,<=1.0.3` the engine matches `mkdocs` first (positions 2–7). The non-greedy `[^\n]*?` then absorbs `trings >=0.25,` and `<=1.0.3` is captured as `currentValue`. Renovate therefore thinks the dependency is **mkdocs** with current `<=1.0.3`, looks up the latest `mkdocs` (1.6.1) on conda-forge, and rewrites the `mkdocstrings` line as `mkdocstrings >=0.25,<=1.6.1` — a non-existent `mkdocstrings` version.

The same prefix collision affects:
- `mkdocs` → `mkdocstrings`, `mkdocstrings-python`, `mkdocs-jupyter`, `mkdocs-gen-files`, `mkdocs-literate-nav`, `mkdocs-section-index`, `mkdocs-material`
- `mkdocstrings` → `mkdocstrings-python`
- `pytest` → `pytest-cov`, `pytest-xdist`
- `gurobi` → `gurobi-logtools`

## Evidence

- #661 — title `mkdocs`, diff updates `mkdocstrings` to `<=1.6.1` (mkdocs's version)
- #684 — title `mkdocs`, diff updates `mkdocs-jupyter` to `<=1.6.1`
- #683 — title `pytest`, body shows `pytest-cov` (`<=7.0.0` → `<=7.4.4`) and `pytest-xdist` (`<=3.8.0` → `<=3.10.1`) labeled as `pytest` and resolved against pytest's old releases

The `pyproject.toml` entries are unaffected because they go through the `pep621` manager which knows package names directly (e.g. #659 worked correctly).

## Fix

Two changes to both `matchStrings` regexes:

1. Require `\s` immediately after the `depName` capture group, so a shorter alternative cannot match when the line continues with `-suffix`.
2. Reorder alternatives longest-first (`mkdocstrings-python` before `mkdocstrings` before `mkdocs`, `pytest-cov`/`pytest-xdist` before `pytest`) as defense-in-depth.

After this change, when the engine tries `mkdocs` on the `mkdocstrings` line, the `\s` constraint fails (next char is `t`), it backtracks, and `mkdocstrings` matches correctly.

## Follow-up

Once merged, the buggy open PRs (#661, #683, #684) should be closed so Renovate regenerates them correctly on the next run.

## Test plan

- [ ] Merge to `develop`
- [ ] Wait for next Renovate scan (Tue 22:00–Wed 06:00 UTC) and verify it produces correctly-labeled PRs
- [ ] Close #661, #683, #684 to trigger regeneration

🤖 Generated with [Claude Code](https://claude.com/claude-code)