### PR TITLE
Centralize string-based options with enums

### DIFF
--- a/fine/IOManagement/standardIO.py
+++ b/fine/IOManagement/standardIO.py
@@ -1,5 +1,6 @@
 import fine as fn
 from fine import utils
+from fine.enums import Dimension
 import pandas as pd
 import datetime
 import time
@@ -120,9 +121,9 @@ def writeOptimizationOutputToExcel(
                 if d["values"] is None:
                     continue
                 if d["timeDependent"]:
-                    if d["dimension"] == "1dim":
+                    if d["dimension"] == Dimension.ONE:
                         dataTD1dim.append(d["values"]), indexTD1dim.append(key)
-                    elif d["dimension"] == "2dim":
+                    elif d["dimension"] == Dimension.TWO:
                         dataTD2dim.append(d["values"]), indexTD2dim.append(key)
                 else:
                     dataTI.append(d["values"]), indexTI.append(key)
@@ -149,9 +150,9 @@ def writeOptimizationOutputToExcel(
                         writer, sheet_name=abbreviatedName + "_TDoptVar_2dim"
                     )
             if dataTI:
-                if esM.componentModelingDict[name].dimension == "1dim":
+                if esM.componentModelingDict[name].dimension == Dimension.ONE:
                     names = ["Variable type", "Component"]
-                elif esM.componentModelingDict[name].dimension == "2dim":
+                elif esM.componentModelingDict[name].dimension == Dimension.TWO:
                     names = ["Variable type", "Component", "Location"]
                 dfTI = pd.concat(dataTI, keys=indexTI, names=names)
                 if oL_ == 1:

--- a/fine/IOManagement/xarrayIO.py
+++ b/fine/IOManagement/xarrayIO.py
@@ -6,6 +6,7 @@ from netCDF4 import Dataset
 import logging
 
 from fine import utils
+from fine.enums import Dimension
 from fine.IOManagement import dictIO, utilsIO
 
 logger = logging.getLogger(__name__)
@@ -97,7 +98,7 @@ def convertOptimizationOutputToDatasets(esM, optSumOutputLevel=0):
             oL = optSumOutputLevel
             oL_ = oL[name] if isinstance(oL, dict) else oL
             optSum = esM.getOptimizationSummary(name, ip=ip, outputLevel=oL_)
-            if esM.componentModelingDict[name].dimension == "1dim":
+            if esM.componentModelingDict[name].dimension == Dimension.ONE:
                 for component in optSum.index.get_level_values(0).unique():
                     variables = optSum.loc[component].index.get_level_values(0)
                     units = optSum.loc[component].index.get_level_values(1)
@@ -121,7 +122,7 @@ def convertOptimizationOutputToDatasets(esM, optSumOutputLevel=0):
                             combine_attrs="drop_conflicts",
                             join="outer",
                         )
-            elif esM.componentModelingDict[name].dimension == "2dim":
+            elif esM.componentModelingDict[name].dimension == Dimension.TWO:
                 for component in optSum.index.get_level_values(0).unique():
                     variables = optSum.loc[component].index.get_level_values(0)
                     units = optSum.loc[component].index.get_level_values(1)
@@ -163,9 +164,9 @@ def convertOptimizationOutputToDatasets(esM, optSumOutputLevel=0):
                 if d["values"] is None:
                     continue
                 if d["timeDependent"]:
-                    if d["dimension"] == "1dim":
+                    if d["dimension"] == Dimension.ONE:
                         dataTD1dim.append(d["values"]), indexTD1dim.append(key)
-                    elif d["dimension"] == "2dim":
+                    elif d["dimension"] == Dimension.TWO:
                         dataTD2dim.append(d["values"]), indexTD2dim.append(key)
                 else:
                     dataTI.append(d["values"]), indexTI.append(key)
@@ -209,7 +210,7 @@ def convertOptimizationOutputToDatasets(esM, optSumOutputLevel=0):
             # Time independent data
             if dataTI:
                 # One dimensional
-                if esM.componentModelingDict[name].dimension == "1dim":
+                if esM.componentModelingDict[name].dimension == Dimension.ONE:
                     names = ["Variable type", "Component"]
                     dfTI = pd.concat(dataTI, keys=indexTI, names=names)
                     for variable in dfTI.index.get_level_values(0).unique():
@@ -225,7 +226,7 @@ def convertOptimizationOutputToDatasets(esM, optSumOutputLevel=0):
                                 [xr_dss[ip][name][component], xr_da], join="outer"
                             )
                 # Two dimensional
-                elif esM.componentModelingDict[name].dimension == "2dim":
+                elif esM.componentModelingDict[name].dimension == Dimension.TWO:
                     names = ["Variable type", "Component", "Location"]
                     dfTI = pd.concat(dataTI, keys=indexTI, names=names)
                     for variable in dfTI.index.get_level_values(0).unique():
@@ -246,7 +247,7 @@ def convertOptimizationOutputToDatasets(esM, optSumOutputLevel=0):
                 if list(xr_dss[ip][name][component].data_vars) == []:
                     # Delete components that have not been built.
                     del xr_dss[ip][name][component]
-                elif esM.componentModelingDict[name].dimension == "2dim":
+                elif esM.componentModelingDict[name].dimension == Dimension.TWO:
                     xr_dss[ip][name][component].coords["locationOut"] = (
                         xr_dss[ip][name][component].coords["locationOut"].astype(str)
                     )

--- a/fine/__init__.py
+++ b/fine/__init__.py
@@ -13,6 +13,7 @@ from .IOManagement.standardIO import (
     plotLocations,
     plotOperation,
     plotOperationColorMap,
+    plotPieChart,
     plotTransmission,
 )
 from .expansionModules.optimizeTSAmultiStage import (
@@ -46,6 +47,7 @@ __all__ = [
     "plotLocations",
     "plotOperation",
     "plotOperationColorMap",
+    "plotPieChart",
     "plotTransmission",
     "subclasses",
     "utils",

--- a/fine/component.py
+++ b/fine/component.py
@@ -1,5 +1,6 @@
 from abc import ABCMeta, abstractmethod
 from fine import utils
+from fine.enums import CostType, Dimension, FncType, VarType
 import fine
 import warnings
 import pyomo.environ as pyomo
@@ -1116,7 +1117,7 @@ class ComponentModel(metaclass=ABCMeta):
             pyomo.Set(dimen=3, initialize=declareOpVarSet),
         )
 
-        if self.dimension == "1dim":
+        if self.dimension == Dimension.ONE:
             # Dictionary which lists all components of the modeling class at one location
             setattr(
                 pyM,
@@ -1134,7 +1135,7 @@ class ComponentModel(metaclass=ABCMeta):
                     for ip in esM.investmentPeriods
                 },
             )
-        elif self.dimension == "2dim":
+        elif self.dimension == Dimension.TWO:
             # Dictionaries which list all outgoing and incoming components at a location
             setattr(
                 pyM,
@@ -3042,7 +3043,7 @@ class ComponentModel(metaclass=ABCMeta):
         QPfactorNames=[],
         QPdivisorNames=[],
         getOptValue=False,
-        getOptValueCostType="TAC",
+        getOptValueCostType=CostType.TAC,
     ):
         """Set design dependent cost equations for the individual components. The equations will be set
         for all components of a modeling class and all locations.
@@ -3085,8 +3086,10 @@ class ComponentModel(metaclass=ABCMeta):
             |br| * the default value is None.
         :type getOptValueCostType: string
         """
-        if getOptValueCostType not in ["TAC", "NPV"]:
-            raise ValueError("The cost types must be 'TAC' or 'NPV'.")
+        try:
+            getOptValueCostType = CostType(getOptValueCostType)
+        except ValueError as exc:
+            raise ValueError("The cost types must be 'TAC' or 'NPV'.") from exc
 
         var = getattr(pyM, varName + "_" + self.abbrvName)
         if esM.stochasticModel:
@@ -3255,11 +3258,11 @@ class ComponentModel(metaclass=ABCMeta):
                             for y in componentYears[compName]
                         ]
                     )
-                    if getOptValueCostType == "NPV":
+                    if getOptValueCostType == CostType.NPV:
                         cost_results[ip].loc[compName, loc] = (
                             cContrSum * utils.discountFactor(esM, ip, compName, loc)
                         )
-                    elif getOptValueCostType == "TAC":
+                    elif getOptValueCostType == CostType.TAC:
                         cost_results[ip].loc[compName, loc] = (
                             cContrSum
                             / utils.annuityPresentValueFactor(
@@ -3427,7 +3430,7 @@ class ComponentModel(metaclass=ABCMeta):
         varName,
         dictName,
         getOptValue=False,
-        getOptValueCostType="TAC",
+        getOptValueCostType=CostType.TAC,
     ):
         """Set time-dependent equations for the individual components. The equations will be set for all components of a modeling class
         and all locations as well as for each considered time step.
@@ -3469,11 +3472,17 @@ class ComponentModel(metaclass=ABCMeta):
             |br| * the default value is None.
         :type getOptValueCostType: string
         """
-        if getOptValueCostType not in ["TAC", "NPV"]:
-            raise ValueError("getOptValueCostType must be either 'TAC' or 'NPV'")
-        if fncType not in ["TD", "TimeSeries"]:
-            raise ValueError("fncType must be either 'TD' or 'TimeSeries'")
-        if fncType == "TimeSeries":
+        try:
+            getOptValueCostType = CostType(getOptValueCostType)
+        except ValueError as exc:
+            raise ValueError(
+                "getOptValueCostType must be either 'TAC' or 'NPV'"
+            ) from exc
+        try:
+            fncType = FncType(fncType)
+        except ValueError as exc:
+            raise ValueError("fncType must be either 'TD' or 'TimeSeries'") from exc
+        if fncType == FncType.TIME_SERIES:
             factorName = factorNames[0]  # noqa: F841
 
         var = getattr(pyM, varName + "_" + self.abbrvName)
@@ -3572,7 +3581,7 @@ class ComponentModel(metaclass=ABCMeta):
                             for y in componentYears[compName]
                         ]
                     )
-                    if getOptValueCostType == "NPV":
+                    if getOptValueCostType == CostType.NPV:
                         cost_results[ip].loc[compName, loc] = (
                             cContrSum
                             * utils.annuityPresentValueFactor(
@@ -3580,7 +3589,7 @@ class ComponentModel(metaclass=ABCMeta):
                             )
                             * utils.discountFactor(esM, ip, compName, loc)
                         )
-                    elif getOptValueCostType == "TAC":
+                    elif getOptValueCostType == CostType.TAC:
                         cost_results[ip].loc[compName, loc] = cContrSum
             return cost_results
         if esM.annuityPerpetuity:
@@ -3676,7 +3685,7 @@ class ComponentModel(metaclass=ABCMeta):
         timeSet_pt = [(p, t) for ip0, p, t in pyM.timeSet if ip0 == ip]
 
         # get factor
-        if fncType == "TD":
+        if fncType == FncType.TD:
             factors = [
                 getattr(self.componentsDict[compName], factorName)[ip][loc]
                 for factorName in factorNames
@@ -3691,7 +3700,7 @@ class ComponentModel(metaclass=ABCMeta):
             # write pd series with constant value for factornames
             mIdx = pd.MultiIndex.from_tuples(timeSet_pt, names=["Period", "TimeStep"])
             factor = pd.Series(factorVal, index=mIdx)
-        elif fncType == "TimeSeries":
+        elif fncType == FncType.TIME_SERIES:
             # if there is not time series, there is not cost contribution
             if getattr(self.componentsDict[compName], factorNames[0])[ip] is None:
                 return 0
@@ -3845,7 +3854,7 @@ class ComponentModel(metaclass=ABCMeta):
             divisorName="CCF",
             QPdivisorNames=["QPbound", "CCF"],
             getOptValue=True,
-            getOptValueCostType="NPV",
+            getOptValueCostType=CostType.NPV,
         )
 
         resultsTAC_cx = self.getEconomicsDesign(
@@ -3858,7 +3867,7 @@ class ComponentModel(metaclass=ABCMeta):
             divisorName="CCF",
             QPdivisorNames=["QPbound", "CCF"],
             getOptValue=True,
-            getOptValueCostType="TAC",
+            getOptValueCostType=CostType.TAC,
         )
 
         resultsNPV_ox = self.getEconomicsDesign(
@@ -3870,7 +3879,7 @@ class ComponentModel(metaclass=ABCMeta):
             varName="commis",
             QPdivisorNames=["QPbound"],
             getOptValue=True,
-            getOptValueCostType="NPV",
+            getOptValueCostType=CostType.NPV,
         )
 
         resultsTAC_ox = self.getEconomicsDesign(
@@ -3882,7 +3891,7 @@ class ComponentModel(metaclass=ABCMeta):
             varName="commis",
             QPdivisorNames=["QPbound"],
             getOptValue=True,
-            getOptValueCostType="TAC",
+            getOptValueCostType=CostType.TAC,
         )
 
         # Get NPV contribution for investmentIfBuilt
@@ -3894,7 +3903,7 @@ class ComponentModel(metaclass=ABCMeta):
             varName="commisBin",
             divisorName="CCF",
             getOptValue=True,
-            getOptValueCostType="NPV",
+            getOptValueCostType=CostType.NPV,
         )
 
         # Calculate the annualized investment costs cx (CAPEX)
@@ -3907,7 +3916,7 @@ class ComponentModel(metaclass=ABCMeta):
             varName="commisBin",
             divisorName="CCF",
             getOptValue=True,
-            getOptValueCostType="TAC",
+            getOptValueCostType=CostType.TAC,
         )
 
         # Get NPV cost contribution for the annualized operational costs if built ox (OPEX)
@@ -3918,7 +3927,7 @@ class ComponentModel(metaclass=ABCMeta):
             lifetimeAttr="ipTechnicalLifetime",
             varName="commisBin",
             getOptValue=True,
-            getOptValueCostType="NPV",
+            getOptValueCostType=CostType.NPV,
         )
 
         # Calculate the annualized operational costs if built ox (OPEX)
@@ -3929,7 +3938,7 @@ class ComponentModel(metaclass=ABCMeta):
             lifetimeAttr="ipTechnicalLifetime",
             varName="commisBin",
             getOptValue=True,
-            getOptValueCostType="TAC",
+            getOptValueCostType=CostType.TAC,
         )
 
         optSummary = {}
@@ -3941,19 +3950,19 @@ class ComponentModel(metaclass=ABCMeta):
             # Get and set optimal variable values for capacities
             values = capVar.get_values()
             capOptVal = utils.formatOptimizationOutput(
-                values, "designVariables", "1dim", ip
+                values, VarType.DESIGN, Dimension.ONE, ip
             )
             capOptVal_ = utils.formatOptimizationOutput(
-                values, "designVariables", self.dimension, ip, compDict=compDict
+                values, VarType.DESIGN, self.dimension, ip, compDict=compDict
             )
             self._capacityVariablesOptimum[esM.investmentPeriodNames[ip]] = capOptVal_
             # Get and set optimal variable values for commissioning
             commisValues = commisVar.get_values()
             commisOptVal = utils.formatOptimizationOutput(
-                commisValues, "designVariables", "1dim", ip
+                commisValues, VarType.DESIGN, Dimension.ONE, ip
             )
             commisOptVal_ = utils.formatOptimizationOutput(
-                commisValues, "designVariables", self.dimension, ip, compDict=compDict
+                commisValues, VarType.DESIGN, self.dimension, ip, compDict=compDict
             )
             self._commissioningVariablesOptimum[esM.investmentPeriodNames[ip]] = (
                 commisOptVal_
@@ -3961,10 +3970,10 @@ class ComponentModel(metaclass=ABCMeta):
             # Get and set optimal variable values for decommissioning
             decommisValues = decommisVar.get_values()
             decommisOptVal = utils.formatOptimizationOutput(
-                decommisValues, "designVariables", "1dim", ip
+                decommisValues, VarType.DESIGN, Dimension.ONE, ip
             )
             decommisOptVal_ = utils.formatOptimizationOutput(
-                decommisValues, "designVariables", self.dimension, ip, compDict=compDict
+                decommisValues, VarType.DESIGN, self.dimension, ip, compDict=compDict
             )
             self._decommissioningVariablesOptimum[esM.investmentPeriodNames[ip]] = (
                 decommisOptVal_
@@ -4124,10 +4133,10 @@ class ComponentModel(metaclass=ABCMeta):
             # Get and set optimal variable values for binary investment decisions (isBuiltBinary).
             values = binVar.get_values()
             binCapOptVal = utils.formatOptimizationOutput(
-                values, "designVariables", "1dim", ip
+                values, VarType.DESIGN, Dimension.ONE, ip
             )
             binCapOptVal_ = utils.formatOptimizationOutput(
-                values, "designVariables", self.dimension, ip=ip, compDict=compDict
+                values, VarType.DESIGN, self.dimension, ip=ip, compDict=compDict
             )
             self._isBuiltVariablesOptimum[esM.investmentPeriodNames[ip]] = binCapOptVal_
 

--- a/fine/conversion.py
+++ b/fine/conversion.py
@@ -1,4 +1,12 @@
 from fine.component import Component, ComponentModel
+from fine.enums import (
+    ComponentAbbreviation,
+    CostType,
+    Dimension,
+    FncType,
+    RampingType,
+    VarType,
+)
 from fine import utils
 import warnings
 import pandas as pd
@@ -270,7 +278,7 @@ class Conversion(Component):
             self,
             esM,
             name,
-            dimension="1dim",
+            dimension=Dimension.ONE,
             hasCapacityVariable=hasCapacityVariable,
             capacityVariableDomain=capacityVariableDomain,
             capacityPerPlantUnit=capacityPerPlantUnit,
@@ -308,7 +316,7 @@ class Conversion(Component):
             esM,
             name,
             opexPerOperation,
-            "1dim",
+            Dimension.ONE,
             locationalEligibility,
             esM.investmentPeriods,
         )
@@ -605,8 +613,8 @@ class ConversionModel(ComponentModel):
     def __init__(self):
         """Create a ConversionModel class instance."""
         super().__init__()
-        self.abbrvName = "conv"
-        self.dimension = "1dim"
+        self.abbrvName = ComponentAbbreviation.CONVERSION
+        self.dimension = Dimension.ONE
         self._operationVariablesOptimum = {}
 
     ####################################################################################################################
@@ -987,10 +995,12 @@ class ConversionModel(ComponentModel):
             |br| * the default value is None.
 
         """
-        if rampingType not in ["rampDownMax", "rampUpMax"]:
+        try:
+            rampingType = RampingType(rampingType)
+        except ValueError as exc:
             raise ValueError(
                 f"Ramping type {rampingType} is not valid. Please choose between rampDownMax and rampUpMax."
-            )
+            ) from exc
 
         compDict, abbrvName = self.componentsDict, self.abbrvName
 
@@ -1004,7 +1014,7 @@ class ConversionModel(ComponentModel):
 
         constrSetRamp = getattr(pyM, f"opConstrSet_{rampingType}_" + abbrvName)
 
-        factor = 1 if rampingType == "rampDownMax" else -1
+        factor = 1 if rampingType == RampingType.DOWN_MAX else -1
 
         if not pyM.hasSegmentation:
             numberOfTimeSteps = len(esM.timeStepsPerPeriod)
@@ -1061,7 +1071,7 @@ class ConversionModel(ComponentModel):
         capVar = getattr(pyM, "cap_" + abbrvName)
         constrSetRamp = getattr(pyM, f"opConstrSet_{rampingType}_" + abbrvName)
 
-        factor = 1 if rampingType == "rampDownMax" else -1
+        factor = 1 if rampingType == RampingType.DOWN_MAX else -1
 
         if not pyM.hasSegmentation:
             numberOfTimeSteps = len(esM.timeStepsPerPeriod)
@@ -1273,11 +1283,11 @@ class ConversionModel(ComponentModel):
             isOperationCommisYearDepending=True,
         )
 
-        self.declareRampingConstraints(pyM, esM, rampingType="rampUpMax")
-        self.declareRampingConstraints(pyM, esM, rampingType="rampDownMax")
+        self.declareRampingConstraints(pyM, esM, rampingType=RampingType.UP_MAX)
+        self.declareRampingConstraints(pyM, esM, rampingType=RampingType.DOWN_MAX)
         if pyM.hasTSA:
-            self.interPeriodRamping(esM, pyM, rampingType="rampUpMax")
-            self.interPeriodRamping(esM, pyM, rampingType="rampDownMax")
+            self.interPeriodRamping(esM, pyM, rampingType=RampingType.UP_MAX)
+            self.interPeriodRamping(esM, pyM, rampingType=RampingType.DOWN_MAX)
 
         ################################################################################################################
         #                                    Declare pathway constraints                                               #
@@ -1647,7 +1657,12 @@ class ConversionModel(ComponentModel):
         :type pyM: pyomo ConcreteModel
         """
         opexOp = self.getEconomicsOperation(
-            pyM, esM, "TD", ["processedOpexPerOperation"], "op", "operationVarDict"
+            pyM,
+            esM,
+            FncType.TD,
+            ["processedOpexPerOperation"],
+            "op",
+            "operationVarDict",
         )
 
         return super().getObjectiveFunctionContribution(esM, pyM) + opexOp
@@ -1677,30 +1692,30 @@ class ConversionModel(ComponentModel):
         resultsTAC_opexOp = self.getEconomicsOperation(
             pyM,
             esM,
-            "TD",
+            FncType.TD,
             ["processedOpexPerOperation"],
             "op",
             "operationVarDict",
             getOptValue=True,
-            getOptValueCostType="TAC",
+            getOptValueCostType=CostType.TAC,
         )
         resultsNPV_opexOp = self.getEconomicsOperation(
             pyM,
             esM,
-            "TD",
+            FncType.TD,
             ["processedOpexPerOperation"],
             "op",
             "operationVarDict",
             getOptValue=True,
-            getOptValueCostType="NPV",
+            getOptValueCostType=CostType.NPV,
         )
 
         for ip in esM.investmentPeriods:
             # Set optimal operation variables and append optimization summary
             optVal = utils.formatOptimizationOutput(
                 opVar.get_values(),
-                "operationVariables",
-                "1dim",
+                VarType.OPERATION,
+                Dimension.ONE,
                 ip,
                 esM.periodsOrder[ip],
                 esM=esM,

--- a/fine/enums.py
+++ b/fine/enums.py
@@ -1,0 +1,64 @@
+"""Central definitions for string-based FINE options."""
+
+from enum import Enum, unique
+
+
+class FineEnum(str, Enum):
+    """String-backed enum that keeps legacy string behavior."""
+
+    def __str__(self):
+        return self.value
+
+
+@unique
+class ComponentAbbreviation(FineEnum):
+    """Abbreviations used in component model names and serialized output."""
+
+    STORAGE = "stor"
+    CONVERSION = "conv"
+    TRANSMISSION = "trans"
+    SOURCE_SINK = "srcSnk"
+    LOPF = "lopf"
+    PART_LOAD = "partLoad"
+    CONVERSION_DYNAMIC = "conv_dyn"
+    PWLCF = "pwlcf"
+
+
+@unique
+class Dimension(FineEnum):
+    """Supported dimensionality labels for component data."""
+
+    ONE = "1dim"
+    TWO = "2dim"
+
+
+@unique
+class VarType(FineEnum):
+    """Optimization variable categories used for result formatting."""
+
+    DESIGN = "designVariables"
+    OPERATION = "operationVariables"
+
+
+@unique
+class CostType(FineEnum):
+    """Cost result types used in economic contribution calculations."""
+
+    TAC = "TAC"
+    NPV = "NPV"
+
+
+@unique
+class FncType(FineEnum):
+    """Function input types for operation-dependent economic calculations."""
+
+    TD = "TD"
+    TIME_SERIES = "TimeSeries"
+
+
+@unique
+class RampingType(FineEnum):
+    """Ramping constraint parameter names."""
+
+    DOWN_MAX = "rampDownMax"
+    UP_MAX = "rampUpMax"

--- a/fine/expansionModules/piecewiseLinearCostFunction.py
+++ b/fine/expansionModules/piecewiseLinearCostFunction.py
@@ -1,4 +1,5 @@
 from fine import utils, utilsPWLCF
+from fine.enums import ComponentAbbreviation, CostType
 import math
 import pyomo.environ as pyomo
 from pyomo.core import Piecewise
@@ -166,7 +167,7 @@ class PiecewiseLinearCostFunctionModel:
     """
 
     def __init__(self):
-        self.abbrvName = "pwlcf"
+        self.abbrvName = ComponentAbbreviation.PWLCF
         self.modulesDict = {}
 
     def declareSets(self, esM, pyM):
@@ -530,7 +531,7 @@ class PiecewiseLinearCostFunctionModel:
         esM,
         pyM,
         getOptValue=False,
-        getOptValueCostType="TAC",
+        getOptValueCostType=CostType.TAC,
     ):
         """Get the economic contribution to the cost function of pwlcf components.
 
@@ -681,12 +682,12 @@ class PiecewiseLinearCostFunctionModel:
                             / len(commis[ip])
                             for y in componentYears[moduleName]
                         )
-                        if getOptValueCostType == "NPV":
+                        if getOptValueCostType == CostType.NPV:
                             cost_results[ip].loc[moduleName, _loc] = (
                                 cContrSum
                                 * utils.discountFactor(esM, ip, moduleName, _loc)
                             )
-                        elif getOptValueCostType == "TAC":
+                        elif getOptValueCostType == CostType.TAC:
                             cost_results[ip].loc[moduleName, _loc] = (
                                 cContrSum
                                 / utils.annuityPresentValueFactor(
@@ -867,10 +868,10 @@ class PiecewiseLinearCostFunctionModel:
         :type pyM: pyomo ConcreteModel
         """
         tac = self.getEconomicsPwlcf(
-            esM, pyM, getOptValue=True, getOptValueCostType="TAC"
+            esM, pyM, getOptValue=True, getOptValueCostType=CostType.TAC
         )
         npv = self.getEconomicsPwlcf(
-            esM, pyM, getOptValue=True, getOptValueCostType="NPV"
+            esM, pyM, getOptValue=True, getOptValueCostType=CostType.NPV
         )
         invest = self.getEconomicsPwlcf(
             esM, pyM, getOptValue=True, getOptValueCostType="invest"

--- a/fine/sourceSink.py
+++ b/fine/sourceSink.py
@@ -1,4 +1,5 @@
 from fine.component import Component, ComponentModel
+from fine.enums import ComponentAbbreviation, CostType, Dimension, FncType, VarType
 from fine import utils
 import pandas as pd
 import warnings
@@ -220,7 +221,7 @@ class Source(Component):
             self,
             esM,
             name,
-            dimension="1dim",
+            dimension=Dimension.ONE,
             hasCapacityVariable=hasCapacityVariable,
             capacityVariableDomain=capacityVariableDomain,
             capacityPerPlantUnit=capacityPerPlantUnit,
@@ -271,7 +272,7 @@ class Source(Component):
             esM,
             name,
             opexPerOperation,
-            "1dim",
+            Dimension.ONE,
             locationalEligibility,
             esM.investmentPeriods,
         )
@@ -282,7 +283,7 @@ class Source(Component):
             esM,
             name,
             commodityCost,
-            "1dim",
+            Dimension.ONE,
             locationalEligibility,
             esM.investmentPeriods,
         )
@@ -293,7 +294,7 @@ class Source(Component):
             esM,
             name,
             commodityRevenue,
-            "1dim",
+            Dimension.ONE,
             locationalEligibility,
             esM.investmentPeriods,
         )
@@ -631,8 +632,8 @@ class SourceSinkModel(ComponentModel):
     def __init__(self):
         """Create a SourceSinkModel class instance."""
         super().__init__()
-        self.abbrvName = "srcSnk"
-        self.dimension = "1dim"
+        self.abbrvName = ComponentAbbreviation.SOURCE_SINK
+        self.dimension = Dimension.ONE
         self._operationVariablesOptimum = {}
 
     ####################################################################################################################
@@ -920,18 +921,28 @@ class SourceSinkModel(ComponentModel):
         :type pym: pyomo ConcreteModel
         """
         opexOp = self.getEconomicsOperation(
-            pyM, esM, "TD", ["processedOpexPerOperation"], "op", "operationVarDict"
+            pyM,
+            esM,
+            FncType.TD,
+            ["processedOpexPerOperation"],
+            "op",
+            "operationVarDict",
         )
         commodCost = self.getEconomicsOperation(
-            pyM, esM, "TD", ["processedCommodityCost"], "op", "operationVarDict"
+            pyM, esM, FncType.TD, ["processedCommodityCost"], "op", "operationVarDict"
         )
         commodRevenue = self.getEconomicsOperation(
-            pyM, esM, "TD", ["processedCommodityRevenue"], "op", "operationVarDict"
+            pyM,
+            esM,
+            FncType.TD,
+            ["processedCommodityRevenue"],
+            "op",
+            "operationVarDict",
         )
         commodCostTimeSeries = self.getEconomicsOperation(
             pyM,
             esM,
-            "TimeSeries",
+            FncType.TIME_SERIES,
             ["processedCommodityCostTimeSeries"],
             "op",
             "operationVarDict",
@@ -939,7 +950,7 @@ class SourceSinkModel(ComponentModel):
         commodRevenueTimeSeries = self.getEconomicsOperation(
             pyM,
             esM,
-            "TimeSeries",
+            FncType.TIME_SERIES,
             ["processedCommodityRevenueTimeSeries"],
             "op",
             "operationVarDict",
@@ -978,102 +989,102 @@ class SourceSinkModel(ComponentModel):
         resultsTAC_opexOp = self.getEconomicsOperation(
             pyM,
             esM,
-            "TD",
+            FncType.TD,
             ["processedOpexPerOperation"],
             "op",
             "operationVarDict",
             getOptValue=True,
-            getOptValueCostType="TAC",
+            getOptValueCostType=CostType.TAC,
         )
         resultsTAC_commodCost = self.getEconomicsOperation(
             pyM,
             esM,
-            "TD",
+            FncType.TD,
             ["processedCommodityCost"],
             "op",
             "operationVarDict",
             getOptValue=True,
-            getOptValueCostType="TAC",
+            getOptValueCostType=CostType.TAC,
         )
         resultsTAC_commodRevenue = self.getEconomicsOperation(
             pyM,
             esM,
-            "TD",
+            FncType.TD,
             ["processedCommodityRevenue"],
             "op",
             "operationVarDict",
             getOptValue=True,
-            getOptValueCostType="TAC",
+            getOptValueCostType=CostType.TAC,
         )
         resultsTAC_commodCostTimeSeries = self.getEconomicsOperation(
             pyM,
             esM,
-            "TimeSeries",
+            FncType.TIME_SERIES,
             ["processedCommodityCostTimeSeries"],
             "op",
             "operationVarDict",
             getOptValue=True,
-            getOptValueCostType="TAC",
+            getOptValueCostType=CostType.TAC,
         )
         resultsTAC_commodRevenueTimeSeries = self.getEconomicsOperation(
             pyM,
             esM,
-            "TimeSeries",
+            FncType.TIME_SERIES,
             ["processedCommodityRevenueTimeSeries"],
             "op",
             "operationVarDict",
             getOptValue=True,
-            getOptValueCostType="TAC",
+            getOptValueCostType=CostType.TAC,
         )
         resultsNPV_opexOp = self.getEconomicsOperation(
             pyM,
             esM,
-            "TD",
+            FncType.TD,
             ["processedOpexPerOperation"],
             "op",
             "operationVarDict",
             getOptValue=True,
-            getOptValueCostType="NPV",
+            getOptValueCostType=CostType.NPV,
         )
         resultsNPV_commodCost = self.getEconomicsOperation(
             pyM,
             esM,
-            "TD",
+            FncType.TD,
             ["processedCommodityCost"],
             "op",
             "operationVarDict",
             getOptValue=True,
-            getOptValueCostType="NPV",
+            getOptValueCostType=CostType.NPV,
         )
         resultsNPV_commodRevenue = self.getEconomicsOperation(
             pyM,
             esM,
-            "TD",
+            FncType.TD,
             ["processedCommodityRevenue"],
             "op",
             "operationVarDict",
             getOptValue=True,
-            getOptValueCostType="NPV",
+            getOptValueCostType=CostType.NPV,
         )
         resultsNPV_commodCostTimeSeries = self.getEconomicsOperation(
             pyM,
             esM,
-            "TimeSeries",
+            FncType.TIME_SERIES,
             ["processedCommodityCostTimeSeries"],
             "op",
             "operationVarDict",
             getOptValue=True,
-            getOptValueCostType="NPV",
+            getOptValueCostType=CostType.NPV,
         )
         resultsNPV_commodRevenueTimeSeries = self.getEconomicsOperation(
             pyM,
             esM,
-            "TimeSeries",
+            FncType.TIME_SERIES,
             ["processedCommodityRevenueTimeSeries"],
             "op",
             "operationVarDict",
             getOptValue=True,
-            getOptValueCostType="NPV",
+            getOptValueCostType=CostType.NPV,
         )
 
         for ip in esM.investmentPeriods:
@@ -1083,8 +1094,8 @@ class SourceSinkModel(ComponentModel):
             # Set optimal operation variables and append optimization summary
             optVal = utils.formatOptimizationOutput(
                 opVar.get_values(),
-                "operationVariables",
-                "1dim",
+                VarType.OPERATION,
+                Dimension.ONE,
                 ip,
                 esM.periodsOrder[ip],
                 esM=esM,

--- a/fine/storage.py
+++ b/fine/storage.py
@@ -1,4 +1,5 @@
 from fine.component import Component, ComponentModel
+from fine.enums import ComponentAbbreviation, CostType, Dimension, FncType, VarType
 from fine import utils
 import pyomo.environ as pyomo
 import warnings
@@ -267,7 +268,7 @@ class Storage(Component):
             self,
             esM,
             name,
-            dimension="1dim",
+            dimension=Dimension.ONE,
             hasCapacityVariable=hasCapacityVariable,
             capacityVariableDomain=capacityVariableDomain,
             capacityPerPlantUnit=capacityPerPlantUnit,
@@ -338,7 +339,7 @@ class Storage(Component):
                 esM,
                 name,
                 opexPerChargeOperation,
-                "1dim",
+                Dimension.ONE,
                 locationalEligibility,
                 esM.investmentPeriods,
             )
@@ -351,7 +352,7 @@ class Storage(Component):
                 esM,
                 name,
                 opexPerDischargeOperation,
-                "1dim",
+                Dimension.ONE,
                 locationalEligibility,
                 esM.investmentPeriods,
             )
@@ -596,8 +597,8 @@ class StorageModel(ComponentModel):
     def __init__(self):
         """Create a StorageModel class instance."""
         super().__init__()
-        self.abbrvName = "stor"
-        self.dimension = "1dim"
+        self.abbrvName = ComponentAbbreviation.STORAGE
+        self.dimension = Dimension.ONE
         self._chargeOperationVariablesOptimum = {}
         self._dischargeOperationVariablesOptimum = {}
         self._stateOfChargeOperationVariablesOptimum = {}
@@ -1864,7 +1865,7 @@ class StorageModel(ComponentModel):
         opexOp1 = self.getEconomicsOperation(
             pyM,
             esM,
-            "TD",
+            FncType.TD,
             ["processedOpexPerChargeOperation"],
             "chargeOp",
             "operationVarDict",
@@ -1872,7 +1873,7 @@ class StorageModel(ComponentModel):
         opexOp2 = self.getEconomicsOperation(
             pyM,
             esM,
-            "TD",
+            FncType.TD,
             ["processedOpexPerDischargeOperation"],
             "dischargeOp",
             "operationVarDict",
@@ -1930,42 +1931,42 @@ class StorageModel(ComponentModel):
         resultsTAC_opexOpCharge = self.getEconomicsOperation(
             pyM,
             esM,
-            "TD",
+            FncType.TD,
             ["processedOpexPerChargeOperation"],
             "chargeOp",
             "operationVarDict",
             getOptValue=True,
-            getOptValueCostType="TAC",
+            getOptValueCostType=CostType.TAC,
         )
         resultsNPV_opexOpCharge = self.getEconomicsOperation(
             pyM,
             esM,
-            "TD",
+            FncType.TD,
             ["processedOpexPerChargeOperation"],
             "chargeOp",
             "operationVarDict",
             getOptValue=True,
-            getOptValueCostType="NPV",
+            getOptValueCostType=CostType.NPV,
         )
         resultsTAC_opexOpDischarge = self.getEconomicsOperation(
             pyM,
             esM,
-            "TD",
+            FncType.TD,
             ["processedOpexPerDischargeOperation"],
             "dischargeOp",
             "operationVarDict",
             getOptValue=True,
-            getOptValueCostType="TAC",
+            getOptValueCostType=CostType.TAC,
         )
         resultsNPV_opexOpDischarge = self.getEconomicsOperation(
             pyM,
             esM,
-            "TD",
+            FncType.TD,
             ["processedOpexPerDischargeOperation"],
             "dischargeOp",
             "operationVarDict",
             getOptValue=True,
-            getOptValueCostType="NPV",
+            getOptValueCostType=CostType.NPV,
         )
 
         for ip in esM.investmentPeriods:
@@ -2047,8 +2048,8 @@ class StorageModel(ComponentModel):
             # * charge variables and contributions
             optVal_charge = utils.formatOptimizationOutput(
                 chargeOp.get_values(),
-                "operationVariables",
-                "1dim",
+                VarType.OPERATION,
+                Dimension.ONE,
                 ip,
                 esM.periodsOrder[ip],
                 esM=esM,
@@ -2109,8 +2110,8 @@ class StorageModel(ComponentModel):
             # * discharge variables and contributions
             optVal_discharge = utils.formatOptimizationOutput(
                 dischargeOp.get_values(),
-                "operationVariables",
-                "1dim",
+                VarType.OPERATION,
+                Dimension.ONE,
                 ip,
                 esM.periodsOrder[ip],
                 esM=esM,
@@ -2183,8 +2184,8 @@ class StorageModel(ComponentModel):
             if not pyM.hasTSA:
                 optVal = utils.formatOptimizationOutput(
                     SOC.get_values(),
-                    "operationVariables",
-                    "1dim",
+                    VarType.OPERATION,
+                    Dimension.ONE,
                     ip,
                     esM.periodsOrder[ip],
                     esM=esM,

--- a/fine/subclasses/conversionDynamic.py
+++ b/fine/subclasses/conversionDynamic.py
@@ -1,4 +1,5 @@
 from fine.conversion import Conversion, ConversionModel
+from fine.enums import ComponentAbbreviation, Dimension
 from fine import utils
 import pyomo.environ as pyomo
 
@@ -74,8 +75,8 @@ class ConversionDynamicModel(ConversionModel):
 
     def __init__(self):
         super().__init__()
-        self.abbrvName = "conv_dyn"
-        self.dimension = "1dim"
+        self.abbrvName = ComponentAbbreviation.CONVERSION_DYNAMIC
+        self.dimension = Dimension.ONE
         self._operationVariablesOptimum = {}
 
     def declareSets(self, esM, pyM):

--- a/fine/subclasses/conversionPartLoad.py
+++ b/fine/subclasses/conversionPartLoad.py
@@ -1,4 +1,5 @@
 from fine.conversion import Conversion, ConversionModel
+from fine.enums import ComponentAbbreviation, Dimension, VarType
 from fine.utils import checkDataFrameConversionFactor, checkCallableConversionFactor
 from fine import utils
 import pyomo.environ as pyomo
@@ -364,8 +365,8 @@ class ConversionPartLoadModel(ConversionModel):
 
     def __init__(self):
         super().__init__()
-        self.abbrvName = "partLoad"
-        self.dimension = "1dim"
+        self.abbrvName = ComponentAbbreviation.PART_LOAD
+        self.dimension = Dimension.ONE
         self._operationVariablesOptimum = {}
         self._discretizationPointVariablesOptimum = {}
         self._discretizationSegmentConVariablesOptimum = {}
@@ -877,24 +878,24 @@ class ConversionPartLoadModel(ConversionModel):
         for ip in esM.investmentPeriods:
             discretizationPointVariablesOptVal_ = utils.formatOptimizationOutput(
                 discretizationPointVariables.get_values(),
-                "operationVariables",
-                "1dim",
+                VarType.OPERATION,
+                Dimension.ONE,
                 ip,
                 esM.periodsOrder[ip],
                 esM=esM,
             )
             discretizationSegmentConVariablesOptVal_ = utils.formatOptimizationOutput(
                 discretizationSegmentConVariables.get_values(),
-                "operationVariables",
-                "1dim",
+                VarType.OPERATION,
+                Dimension.ONE,
                 ip,
                 esM.periodsOrder[ip],
                 esM=esM,
             )
             discretizationSegmentBinVariablesOptVal_ = utils.formatOptimizationOutput(
                 discretizationSegmentBinVariables.get_values(),
-                "operationVariables",
-                "1dim",
+                VarType.OPERATION,
+                Dimension.ONE,
                 ip,
                 esM.periodsOrder[ip],
                 esM=esM,

--- a/fine/subclasses/lopf.py
+++ b/fine/subclasses/lopf.py
@@ -1,5 +1,6 @@
 from fine.transmission import Transmission, TransmissionModel
 from fine import utils
+from fine.enums import ComponentAbbreviation, Dimension, VarType
 import pyomo.environ as pyomo
 import pandas as pd
 
@@ -118,8 +119,8 @@ class LOPFModel(TransmissionModel):
 
     def __init__(self):
         super().__init__()
-        self.abbrvName = "lopf"
-        self.dimension = "2dim"
+        self.abbrvName = ComponentAbbreviation.LOPF
+        self.dimension = Dimension.TWO
         self._operationVariablesOptimum = {}
         self._phaseAngleVariablesOptimum = {}
 
@@ -328,8 +329,8 @@ class LOPFModel(TransmissionModel):
 
             optVal_ = utils.formatOptimizationOutput(
                 phaseAngleVar.get_values(),
-                "operationVariables",
-                "1dim",
+                VarType.OPERATION,
+                Dimension.ONE,
                 ip,
                 esM.periodsOrder[ip],
                 esM=esM,
@@ -360,7 +361,7 @@ class LOPFModel(TransmissionModel):
             "capacityVariablesOptimum": self.dimension,
             "isBuiltVariablesOptimum": self.dimension,
             "operationVariablesOptimum": self.dimension,
-            "phaseAngleVariablesOptimum": "1dim",
+            "phaseAngleVariablesOptimum": Dimension.ONE,
         }
 
         if name in timeDependentMapping:

--- a/fine/transmission.py
+++ b/fine/transmission.py
@@ -1,6 +1,7 @@
 import warnings
 
 from fine.component import Component, ComponentModel
+from fine.enums import ComponentAbbreviation, CostType, Dimension, FncType, VarType
 from fine import utils
 import pyomo.environ as pyomo
 import pandas as pd
@@ -205,7 +206,7 @@ class Transmission(Component):
             self.isBuiltFix,
             hasCapacityVariable,
             operationTimeSeries,
-            "2dim",
+            Dimension.TWO,
         )
 
         self._mapC, self._mapL, self._mapI = {}, {}, {}
@@ -272,7 +273,7 @@ class Transmission(Component):
             self,
             esM,
             name,
-            dimension="2dim",
+            dimension=Dimension.TWO,
             hasCapacityVariable=hasCapacityVariable,
             capacityVariableDomain=capacityVariableDomain,
             capacityPerPlantUnit=capacityPerPlantUnit,
@@ -407,7 +408,7 @@ class Transmission(Component):
             esM,
             name,
             self.opexPerOperation,
-            "2dim",
+            Dimension.TWO,
             self.locationalEligibility,
             esM.investmentPeriods,
         )
@@ -415,7 +416,7 @@ class Transmission(Component):
         # operationRateMax
         self.operationRateMax = operationRateMax
         self.fullOperationRateMax = utils.checkAndSetInvestmentPeriodTimeSeries(
-            esM, name, operationRateMax, self.locationalEligibility, "2dim"
+            esM, name, operationRateMax, self.locationalEligibility, Dimension.TWO
         )
         self.aggregatedOperationRateMax = dict.fromkeys(esM.investmentPeriods)
         self.processedOperationRateMax = dict.fromkeys(esM.investmentPeriods)
@@ -423,7 +424,7 @@ class Transmission(Component):
         # operationRateFix
         self.operationRateFix = operationRateFix
         self.fullOperationRateFix = utils.checkAndSetInvestmentPeriodTimeSeries(
-            esM, name, operationRateFix, self.locationalEligibility, "2dim"
+            esM, name, operationRateFix, self.locationalEligibility, Dimension.TWO
         )
         self.aggregatedOperationRateFix = dict.fromkeys(esM.investmentPeriods)
         self.processedOperationRateFix = dict.fromkeys(esM.investmentPeriods)
@@ -520,8 +521,8 @@ class TransmissionModel(ComponentModel):
     def __init__(self):
         """Create a TransmissionModel class instance."""
         super().__init__()
-        self.abbrvName = "trans"
-        self.dimension = "2dim"
+        self.abbrvName = ComponentAbbreviation.TRANSMISSION
+        self.dimension = Dimension.TWO
         self._operationVariablesOptimum = {}
         self._isBuiltVariablesOptimum = {}
 
@@ -899,7 +900,12 @@ class TransmissionModel(ComponentModel):
         :type pyM: pyomo ConcreteModel
         """
         opexOp = self.getEconomicsOperation(
-            pyM, esM, "TD", ["processedOpexPerOperation"], "op", "operationVarDictOut"
+            pyM,
+            esM,
+            FncType.TD,
+            ["processedOpexPerOperation"],
+            "op",
+            "operationVarDictOut",
         )
 
         capexCap = self.getEconomicsDesign(
@@ -964,22 +970,22 @@ class TransmissionModel(ComponentModel):
         resultsTAC_opexOp = self.getEconomicsOperation(
             pyM,
             esM,
-            "TD",
+            FncType.TD,
             ["processedOpexPerOperation"],
             "op",
             "operationVarDict",
             getOptValue=True,
-            getOptValueCostType="TAC",
+            getOptValueCostType=CostType.TAC,
         )
         resultsNPV_opexOp = self.getEconomicsOperation(
             pyM,
             esM,
-            "TD",
+            FncType.TD,
             ["processedOpexPerOperation"],
             "op",
             "operationVarDict",
             getOptValue=True,
-            getOptValueCostType="NPV",
+            getOptValueCostType=CostType.NPV,
         )
         for ip in esM.investmentPeriods:
             for compName, comp in compDict.items():
@@ -989,7 +995,7 @@ class TransmissionModel(ComponentModel):
                     "capexIfBuilt",
                     "opexCap",
                     "opexIfBuilt",
-                    "TAC",
+                    CostType.TAC,
                 ]:
                     data = optSummaryBasic[esM.investmentPeriodNames[ip]].loc[
                         compName, cost
@@ -1001,16 +1007,16 @@ class TransmissionModel(ComponentModel):
             # Set optimal operation variables and append optimization summary
             optVal = utils.formatOptimizationOutput(
                 opVar.get_values(),
-                "operationVariables",
-                "1dim",
+                VarType.OPERATION,
+                Dimension.ONE,
                 ip,
                 esM.periodsOrder[ip],
                 esM=esM,
             )
             optVal_ = utils.formatOptimizationOutput(
                 opVar.get_values(),
-                "operationVariables",
-                "2dim",
+                VarType.OPERATION,
+                Dimension.TWO,
                 ip,
                 esM.periodsOrder[ip],
                 compDict=compDict,

--- a/fine/utils.py
+++ b/fine/utils.py
@@ -7,6 +7,7 @@ import pandas as pd
 import gurobipy as gp
 
 import fine as fn
+from fine.enums import Dimension, VarType
 
 
 def checkAndSetBalanceLimitID(balanceLimitID):
@@ -407,11 +408,11 @@ def checkLocationSpecficDesignInputParams(comp, esM):
 
     def checkAndSet(data, comp, esM):
         if data is not None:
-            if comp.dimension == "1dim":
+            if comp.dimension == Dimension.ONE:
                 if not isinstance(data, pd.Series):
                     raise TypeError("Input data has to be a pandas Series")
                 data = checkRegionalIndex(esM, data, comp.locationalEligibility)
-            elif comp.dimension == "2dim":
+            elif comp.dimension == Dimension.TWO:
                 if not isinstance(data, pd.Series):
                     raise TypeError("Input data has to be a pandas DataFrame")
                 data = checkConnectionIndex(data, comp.locationalEligibility)
@@ -940,7 +941,7 @@ def setLocationalEligibility(
     isBuiltFix,
     hasCapacityVariable,
     operationTimeSeries,
-    dimension="1dim",
+    dimension=Dimension.ONE,
 ):
     """MISSING."""
     # ruff: noqa: PLR0911 # needed to avoid ruff saying "too many return statements"
@@ -948,12 +949,12 @@ def setLocationalEligibility(
         if isinstance(locationalEligibility, pd.Series):
             esm_locations = set(esM.locations)
             le_index = set(locationalEligibility.index)
-            if dimension == "1dim":
+            if dimension == Dimension.ONE:
                 if esm_locations != le_index:
                     raise ValueError(
                         "if locationalEligibility (1dim) is specified, it needs to match the esM locations"
                     )
-            elif dimension == "2dim":
+            elif dimension == Dimension.TWO:
                 le_index_2dim = set(
                     f"{a}_{b}"
                     for a in sorted(esm_locations)
@@ -1005,7 +1006,7 @@ def setLocationalEligibility(
         and operationTimeSeries is not None
         and any(ots is not None for ots in operationTimeSeries.values())
     ):
-        if dimension == "1dim":
+        if dimension == Dimension.ONE:
             data = 0
             # sum values over ips
             for ip in esM.investmentPeriods:
@@ -1014,7 +1015,7 @@ def setLocationalEligibility(
             data[data > 0] = 1
             return data
         # Problems here ? Adapt this?
-        if dimension == "2dim":
+        if dimension == Dimension.TWO:
             # New for perfect foresight
             data = 0
             # sum values over ips
@@ -1030,7 +1031,7 @@ def setLocationalEligibility(
         and (isBuiltFix is None or isinstance(isBuiltFix, int))
     ):
         # If no information is given, or all information is given as float or integer, all values are set to 1
-        if dimension == "1dim":
+        if dimension == Dimension.ONE:
             return pd.Series([1 for loc in esM.locations], index=esM.locations)
         keys = {
             loc1 + "_" + loc2
@@ -1060,7 +1061,7 @@ def setLocationalEligibility(
         raise NotImplementedError()
 
     # First setup series with only 0
-    if dimension == "1dim":
+    if dimension == Dimension.ONE:
         regions = esM.locations
     else:
         firstYear = sorted(data.keys())[0]
@@ -1077,7 +1078,7 @@ def setLocationalEligibility(
 
 
 def checkAndSetInvestmentPeriodTimeSeries(
-    esM, name, data, locationalEligibility, dimension="1dim"
+    esM, name, data, locationalEligibility, dimension=Dimension.ONE
 ):
     """MISSING."""
     checkInvestmentPeriodParameters(name, data, esM.investmentPeriodNames)
@@ -1108,7 +1109,7 @@ def checkAndSetInvestmentPeriodTimeSeries(
 
 
 def checkAndSetInvestmentPeriodCostTimeSeries(
-    esM, name, data, locationalEligibility, dimension="1dim"
+    esM, name, data, locationalEligibility, dimension=Dimension.ONE
 ):
     """MISSING."""
     if (
@@ -1125,7 +1126,7 @@ def checkAndSetInvestmentPeriodCostTimeSeries(
 
 
 def checkAndSetTimeSeries(
-    esM, name, operationTimeSeries, locationalEligibility, dimension="1dim"
+    esM, name, operationTimeSeries, locationalEligibility, dimension=Dimension.ONE
 ):
     """MISSING."""
     if operationTimeSeries is not None:
@@ -1153,7 +1154,7 @@ def checkAndSetTimeSeries(
                 )
         checkTimeSeriesIndex(esM, operationTimeSeries)
 
-        if dimension == "1dim":
+        if dimension == Dimension.ONE:
             operationTimeSeries = checkRegionalColumnTitles(
                 esM, operationTimeSeries, locationalEligibility
             )
@@ -1171,7 +1172,7 @@ def checkAndSetTimeSeries(
                         + " eligibilities."
                     )
 
-        elif dimension == "2dim":
+        elif dimension == Dimension.TWO:
             keys = {
                 loc1 + "_" + loc2 for loc1 in esM.locations for loc2 in esM.locations
             }
@@ -1334,7 +1335,7 @@ def checkAndSetCostParameter(esM, name, data, dimension, locationalEligibility):
             f"Initialization error in {name} detected.\n"
             "Economic parameters contain NaN values which are not allowed."
         )
-    if dimension == "1dim":
+    if dimension == Dimension.ONE:
         if not (
             isinstance(data, int)
             or isinstance(data, float)
@@ -1346,7 +1347,7 @@ def checkAndSetCostParameter(esM, name, data, dimension, locationalEligibility):
                 + " detected.\n"
                 + "Economic parameters have to be a number or a pandas Series."
             )
-    elif dimension == "2dim":
+    elif dimension == Dimension.TWO:
         if not (
             isinstance(data, int)
             or isinstance(data, float)
@@ -1361,7 +1362,7 @@ def checkAndSetCostParameter(esM, name, data, dimension, locationalEligibility):
     else:
         raise ValueError("The dimension parameter has to be either '1dim' or '2dim' ")
 
-    if dimension == "1dim":
+    if dimension == Dimension.ONE:
         if isinstance(data, int) or isinstance(data, float):
             if data < 0:
                 raise ValueError(
@@ -1734,11 +1735,11 @@ def checkAndSetFullLoadHoursParameter(
                         + name
                         + " detected.\n Full load hours limitations have to be positive."
                     )
-                if dimension == "1dim":
+                if dimension == Dimension.ONE:
                     parameter[ip] = pd.Series(
                         [float(_data) for loc in esM.locations], index=esM.locations
                     )
-                elif dimension == "2dim":
+                elif dimension == Dimension.TWO:
                     parameter[ip] = pd.Series(
                         [float(_data) for loc in locationalEligibility.index],
                         index=locationalEligibility.index,
@@ -1925,7 +1926,7 @@ def formatOptimizationOutput(
     if not data:
         return None
     # If the dictionary is not empty, format it into a DataFrame
-    if varType == "designVariables" and dimension == "1dim":
+    if varType == VarType.DESIGN and dimension == Dimension.ONE:
         # Convert dictionary to DataFrame, transpose, put the components name first and sort the index
         # Results in a one dimensional DataFrame
         df = pd.DataFrame(data, index=[0]).T.swaplevel(i=0, j=1, axis=0).sort_index()
@@ -1938,7 +1939,7 @@ def formatOptimizationOutput(
         # Get rid of the unnecessary 0 level
         df.columns = df.columns.droplevel()
         return df
-    if varType == "designVariables" and dimension == "2dim":
+    if varType == VarType.DESIGN and dimension == Dimension.TWO:
         # Convert dictionary to DataFrame, transpose, put the components name first while keeping the order of the
         # regions and sort the index
         # Results in a one dimensional DataFrame
@@ -1957,7 +1958,7 @@ def formatOptimizationOutput(
         # Get rid of the unnecessary 0 level
         df.columns = df.columns.droplevel()
         return df
-    if varType == "operationVariables" and dimension == "1dim":
+    if varType == VarType.OPERATION and dimension == Dimension.ONE:
         # Convert dictionary to DataFrame, transpose, put the period column first and sort the index
 
         # Results in a one dimensional DataFrame
@@ -1975,7 +1976,7 @@ def formatOptimizationOutput(
         # drop ip from index
         df.reset_index(level=2, drop=True, inplace=True)
         return buildFullTimeSeries(df, periodsOrder, ip, esM=esM)
-    if varType == "operationVariables" and dimension == "2dim":
+    if varType == VarType.OPERATION and dimension == Dimension.TWO:
         # Convert dictionary to DataFrame, transpose, put the period column first while keeping the order of the
         # regions and sort the index
         # Results in a one dimensional DataFrame
@@ -2261,9 +2262,9 @@ def checkAndSetStock(component, esM, stockCommissioning):
         raise TypeError("stockCommissioning must be None or a dict")
 
     # get regions
-    if component.dimension == "1dim":
+    if component.dimension == Dimension.ONE:
         regions = esM.locations
-    if component.dimension == "2dim":
+    if component.dimension == Dimension.TWO:
         regions = [
             loc1 + "_" + loc2
             for loc1 in esM.locations
@@ -2398,9 +2399,9 @@ def checkAndSetStock(component, esM, stockCommissioning):
 
 def setStockCapacityStartYear(component, esM, dimension):
     """Missing."""
-    if dimension == "1dim":
+    if dimension == Dimension.ONE:
         regions = esM.locations
-    elif dimension == "2dim":
+    elif dimension == Dimension.TWO:
         regions = [
             loc1 + "_" + loc2
             for loc1 in esM.locations

--- a/test/test_enums.py
+++ b/test/test_enums.py
@@ -1,0 +1,45 @@
+from fine.enums import (
+    ComponentAbbreviation,
+    CostType,
+    Dimension,
+    FncType,
+    RampingType,
+    VarType,
+)
+
+
+def test_enums_keep_legacy_string_values():
+    assert ComponentAbbreviation.STORAGE == "stor"
+    assert ComponentAbbreviation.CONVERSION == "conv"
+    assert ComponentAbbreviation.TRANSMISSION == "trans"
+    assert ComponentAbbreviation.SOURCE_SINK == "srcSnk"
+    assert ComponentAbbreviation.LOPF == "lopf"
+    assert ComponentAbbreviation.PART_LOAD == "partLoad"
+    assert ComponentAbbreviation.CONVERSION_DYNAMIC == "conv_dyn"
+    assert ComponentAbbreviation.PWLCF == "pwlcf"
+
+    assert Dimension.ONE == "1dim"
+    assert Dimension.TWO == "2dim"
+    assert VarType.DESIGN == "designVariables"
+    assert VarType.OPERATION == "operationVariables"
+    assert CostType.TAC == "TAC"
+    assert CostType.NPV == "NPV"
+    assert FncType.TD == "TD"
+    assert FncType.TIME_SERIES == "TimeSeries"
+    assert RampingType.DOWN_MAX == "rampDownMax"
+    assert RampingType.UP_MAX == "rampUpMax"
+
+
+def test_enums_preserve_string_operations():
+    assert str(Dimension.ONE) == "1dim"
+    assert "operationVarSet_" + ComponentAbbreviation.CONVERSION == (
+        "operationVarSet_conv"
+    )
+    assert f"ConstrInterPeriod_{RampingType.UP_MAX}_conv" == (
+        "ConstrInterPeriod_rampUpMax_conv"
+    )
+
+
+def test_component_abbreviations_are_unique():
+    values = [member.value for member in ComponentAbbreviation]
+    assert len(values) == len(set(values))


### PR DESCRIPTION
Add string-backed enums for FINE option values such as component abbreviations, dimensions, variable types, cost types, function types, and ramping types. Replace the main magic-string assignments, comparisons, and validation paths with enum members while preserving the exact legacy string values used in saved models, xarray/excel IO, and Pyomo naming. Add enum compatibility tests to ensure members still compare equal to their legacy string values and keep existing string concatenation behavior.