### PR TITLE
Expose plotPieChart function at the package level

### DIFF
--- a/fine/__init__.py
+++ b/fine/__init__.py
@@ -14,6 +14,7 @@ from .IOManagement.standardIO import (
     plotOperation,
     plotOperationColorMap,
     plotTransmission,
+    plotPieChart,
 )
 from .expansionModules.optimizeTSAmultiStage import (
     fixBinaryVariables,

--- a/fine/__init__.py
+++ b/fine/__init__.py
@@ -48,6 +48,7 @@ __all__ = [
     "plotOperation",
     "plotOperationColorMap",
     "plotTransmission",
+    "plotPieChart",
     "subclasses",
     "utils",
     "xarrayIO",


### PR DESCRIPTION
added plotPieChart to init.py

https://github.com/FZJ-IEK3-VSA/FINE/pull/707 removed wildcards imports in the fine init.py
But only included functions that were used at that time.

Later, https://github.com/FZJ-IEK3-VSA/FINE/pull/708 added a test for plotPieChart importing it as fn.plotPieChart but did not add it to the imports in the init.py