### PR TITLE
776 support pandas 3

### DIFF
--- a/fine/IOManagement/dictIO.py
+++ b/fine/IOManagement/dictIO.py
@@ -16,7 +16,7 @@ def reconstruct_full_timeseries(esM, timeseries, ip):
 
     # switch first index level and column level
     df = timeseries.copy()
-    df = df.stack().unstack(level=1)
+    df = df.stack(future_stack=True).dropna().unstack(level=1)
     number_of_index_level = df.index.nlevels
     df.index.set_names(names=[None] * number_of_index_level, inplace=True)
     full_df = (

--- a/fine/IOManagement/standardIO.py
+++ b/fine/IOManagement/standardIO.py
@@ -271,7 +271,7 @@ def getShadowPrices(
         SP = fn.utils.buildFullTimeSeries(
             SP, periodsOrder[ip], ip, esM=esM, divide=False
         )
-        SP = SP.stack()
+        SP = SP.stack(future_stack=True).dropna()
 
     return SP
 

--- a/fine/IOManagement/utilsIO.py
+++ b/fine/IOManagement/utilsIO.py
@@ -497,7 +497,11 @@ def add2dVariableToDict(
     :return: component_dict
     """
     if drop_component:
-        series = comp_var_xr.drop("component").to_dataframe().stack(level=0, future_stack=True)
+        series = (
+            comp_var_xr.drop("component")
+            .to_dataframe()
+            .stack(level=0, future_stack=True)
+        )
     else:
         series = comp_var_xr.to_dataframe().stack(level=0, future_stack=True)
     series.index = series.index.droplevel(level=2).map("_".join)

--- a/fine/IOManagement/utilsIO.py
+++ b/fine/IOManagement/utilsIO.py
@@ -189,7 +189,7 @@ def _leafToIndexedData(data, classname, component, _mapC_dict, locations):
 
     # regional time series (time, space) - or (time, space, space_2) for Transmission
     if isinstance(data, pd.DataFrame):
-        multi_index_dataframe = data.stack()
+        multi_index_dataframe = data.stack(future_stack=True).dropna()
         if "Period" in multi_index_dataframe.index.names:
             multi_index_dataframe = multi_index_dataframe.droplevel(0)
 
@@ -218,7 +218,7 @@ def _leafToIndexedData(data, classname, component, _mapC_dict, locations):
         if isTransmission:
             # 2d (space, space_2): series indices are packed like loc1_loc2
             df = transform1dSeriesto2dDataFrame(data, locations)
-            multi_index_dataframe = df.stack()
+            multi_index_dataframe = df.stack(future_stack=True).dropna()
             multi_index_dataframe.index.set_names(["space", "space_2"], inplace=True)
             return "2d_", multi_index_dataframe
 
@@ -497,9 +497,9 @@ def add2dVariableToDict(
     :return: component_dict
     """
     if drop_component:
-        series = comp_var_xr.drop("component").to_dataframe().stack(level=0)
+        series = comp_var_xr.drop("component").to_dataframe().stack(level=0, future_stack=True)
     else:
-        series = comp_var_xr.to_dataframe().stack(level=0)
+        series = comp_var_xr.to_dataframe().stack(level=0, future_stack=True)
     series.index = series.index.droplevel(level=2).map("_".join)
 
     # NOTE: In FINE, a check is made to make sure that locationalEligibility indices matches indices of other

--- a/fine/IOManagement/xarrayIO.py
+++ b/fine/IOManagement/xarrayIO.py
@@ -191,7 +191,11 @@ def convertOptimizationOutputToDatasets(esM, optSumOutputLevel=0):
                     for component in (
                         dfTD1dim.loc[variable].index.get_level_values(0).unique()
                     ):
-                        df = dfTD1dim.loc[(variable, component)].T.stack(future_stack=True).dropna()
+                        df = (
+                            dfTD1dim.loc[(variable, component)]
+                            .T.stack(future_stack=True)
+                            .dropna()
+                        )
                         df.name = rename_optimum_variables.get(variable, variable)
                         df.index.rename(["time", "location"], inplace=True)
                         xr_da = df.to_xarray()
@@ -208,7 +212,11 @@ def convertOptimizationOutputToDatasets(esM, optSumOutputLevel=0):
                     for component in (
                         dfTD2dim.loc[variable].index.get_level_values(0).unique()
                     ):
-                        df = dfTD2dim.loc[(variable, component)].stack(future_stack=True).dropna()
+                        df = (
+                            dfTD2dim.loc[(variable, component)]
+                            .stack(future_stack=True)
+                            .dropna()
+                        )
 
                         df.name = rename_optimum_variables.get(variable, variable)
                         df.index.rename(
@@ -246,7 +254,11 @@ def convertOptimizationOutputToDatasets(esM, optSumOutputLevel=0):
                         for component in (
                             dfTI.loc[variable].index.get_level_values(0).unique()
                         ):
-                            df = dfTI.loc[(variable, component)].T.stack(future_stack=True).dropna()
+                            df = (
+                                dfTI.loc[(variable, component)]
+                                .T.stack(future_stack=True)
+                                .dropna()
+                            )
                             df.name = variable
                             df.index.rename(["locationIn", "locationOut"], inplace=True)
                             xr_da = df.to_xarray()

--- a/fine/IOManagement/xarrayIO.py
+++ b/fine/IOManagement/xarrayIO.py
@@ -139,7 +139,7 @@ def convertOptimizationOutputToDatasets(esM, optSumOutputLevel=0):
                             df.index = df.index.droplevel(0)
 
                         # df = df.iloc[-1]
-                        df = df.stack()
+                        df = df.stack(future_stack=True).dropna()
                         # df.name = (name, component, variables
                         df.name = variable
                         df.index.rename(["locationIn", "locationOut"], inplace=True)
@@ -191,7 +191,7 @@ def convertOptimizationOutputToDatasets(esM, optSumOutputLevel=0):
                     for component in (
                         dfTD1dim.loc[variable].index.get_level_values(0).unique()
                     ):
-                        df = dfTD1dim.loc[(variable, component)].T.stack()
+                        df = dfTD1dim.loc[(variable, component)].T.stack(future_stack=True).dropna()
                         df.name = rename_optimum_variables.get(variable, variable)
                         df.index.rename(["time", "location"], inplace=True)
                         xr_da = df.to_xarray()
@@ -208,7 +208,7 @@ def convertOptimizationOutputToDatasets(esM, optSumOutputLevel=0):
                     for component in (
                         dfTD2dim.loc[variable].index.get_level_values(0).unique()
                     ):
-                        df = dfTD2dim.loc[(variable, component)].stack()
+                        df = dfTD2dim.loc[(variable, component)].stack(future_stack=True).dropna()
 
                         df.name = rename_optimum_variables.get(variable, variable)
                         df.index.rename(
@@ -246,7 +246,7 @@ def convertOptimizationOutputToDatasets(esM, optSumOutputLevel=0):
                         for component in (
                             dfTI.loc[variable].index.get_level_values(0).unique()
                         ):
-                            df = dfTI.loc[(variable, component)].T.stack()
+                            df = dfTI.loc[(variable, component)].T.stack(future_stack=True).dropna()
                             df.name = variable
                             df.index.rename(["locationIn", "locationOut"], inplace=True)
                             xr_da = df.to_xarray()

--- a/fine/results/frames.py
+++ b/fine/results/frames.py
@@ -101,7 +101,9 @@ def shapeOptimumResult(sub, name, timeDependent, dimension):
             # extra index levels (e.g. discretizationIndex) sit before location; stack
             # every column level so nothing is lost or collides on export, keeping the
             # level names set by formatOptimizationOutput.
-            series = subT.stack(list(range(subT.columns.nlevels)), future_stack=True).dropna()
+            series = subT.stack(
+                list(range(subT.columns.nlevels)), future_stack=True
+            ).dropna()
             extraNames = list(sub.index.names[:-1])
             series.index = series.index.rename(["time", *extraNames, "location"])
     elif timeDependent and dimension == Dimension.TWO:

--- a/fine/results/frames.py
+++ b/fine/results/frames.py
@@ -95,23 +95,23 @@ def shapeOptimumResult(sub, name, timeDependent, dimension):
     if timeDependent and dimension == Dimension.ONE:
         subT = sub.T
         if subT.columns.nlevels == 1:
-            series = subT.stack()
+            series = subT.stack(future_stack=True).dropna()
             series.index = series.index.rename(["time", "location"])
         else:
             # extra index levels (e.g. discretizationIndex) sit before location; stack
             # every column level so nothing is lost or collides on export, keeping the
             # level names set by formatOptimizationOutput.
-            series = subT.stack(list(range(subT.columns.nlevels)))
+            series = subT.stack(list(range(subT.columns.nlevels)), future_stack=True).dropna()
             extraNames = list(sub.index.names[:-1])
             series.index = series.index.rename(["time", *extraNames, "location"])
     elif timeDependent and dimension == Dimension.TWO:
-        series = sub.stack()
+        series = sub.stack(future_stack=True).dropna()
         series.index = series.index.rename(["locationIn", "locationOut", "time"])
         series = series.reorder_levels(["time", "locationIn", "locationOut"])
     elif not timeDependent and dimension == Dimension.ONE:
         series = sub.rename_axis("location")
     else:  # time-independent 2-dim
-        series = sub.T.stack()
+        series = sub.T.stack(future_stack=True).dropna()
         series.index = series.index.rename(["locationIn", "locationOut"])
     series = series.copy()
     series.name = name

--- a/fine/transmission.py
+++ b/fine/transmission.py
@@ -1123,7 +1123,7 @@ class TransmissionModel(ComponentModel):
             # rows would lose the unconnected location pairs.
 
             # Split connection indices to two location indices
-            optSummary = optSummary.stack()
+            optSummary = optSummary.stack(future_stack=True).dropna()
             indexNew = []
             for tup in optSummary.index.tolist():
                 loc1, loc2 = mapC[tup[3]]


### PR DESCRIPTION
Updated pandas stack() calls to use future_stack=True, making FINE compatible with the stack implementation used by pandas 3. Where FINE previously relied on the legacy stack() behavior to implicitly drop NaN values, .dropna() is now applied explicitly to preserve the existing output and ensure consistent results across pandas 2 and pandas 3.